### PR TITLE
fix(ui): render toast message as text

### DIFF
--- a/public/js/ui.js
+++ b/public/js/ui.js
@@ -17,7 +17,12 @@ function showToast(message, type = "info", duration = 3500) {
   const icons = { success: "✅", error: "❌", info: "ℹ️", warning: "⚠️" };
   const toast = document.createElement("div");
   toast.className = `toast toast-${type === "error" ? "error" : type === "success" ? "success" : "info"}`;
-  toast.innerHTML = `<span>${icons[type] || icons.info}</span><span>${message}</span>`;
+  const iconSpan = document.createElement("span");
+  iconSpan.textContent = icons[type] || icons.info;
+  const messageSpan = document.createElement("span");
+  messageSpan.textContent = String(message);
+  toast.appendChild(iconSpan);
+  toast.appendChild(messageSpan);
   container.appendChild(toast);
   setTimeout(() => {
     toast.style.opacity = "0";


### PR DESCRIPTION
## Summary
Hardens toast rendering against DOM XSS by removing direct HTML interpolation of message content.
## Changes
- Replaced `innerHTML` with explicit `span` elements.
- Set icon and message using `textContent`.
- Preserved existing toast styles/behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of toast notification message rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->