### PR TITLE
fix(consent): enforce legal attestation for templates

### DIFF
--- a/src/pages/consent.html
+++ b/src/pages/consent.html
@@ -316,8 +316,8 @@
                       name: 'All Participants',
                       purpose: 'Video call recording',
                       details: 'Explicit consent given before session start via in-app prompt',
-                    }).then(() => {
-                      if (typeof renderConsentPage === 'function') {
+                    }).then((entry) => {
+                      if (entry && typeof renderConsentPage === 'function') {
                         renderConsentPage();
                       }
                     })
@@ -334,8 +334,8 @@
                       name: 'All Participants',
                       purpose: 'AI meeting notes',
                       details: 'Consent to generate encrypted AI notes from meeting content',
-                    }).then(() => {
-                      if (typeof renderConsentPage === 'function') {
+                    }).then((entry) => {
+                      if (entry && typeof renderConsentPage === 'function') {
                         renderConsentPage();
                       }
                     })
@@ -352,8 +352,8 @@
                       name: 'System',
                       purpose: 'Session metadata',
                       details: 'Secure session initiated; all participants anonymized',
-                    }).then(() => {
-                      if (typeof renderConsentPage === 'function') {
+                    }).then((entry) => {
+                      if (entry && typeof renderConsentPage === 'function') {
                         renderConsentPage();
                       }
                     })
@@ -371,8 +371,8 @@
                       purpose: 'Right to erasure',
                       details:
                         'Participant has withdrawn consent and requested data deletion (GDPR Art. 17)',
-                    }).then(() => {
-                      if (typeof renderConsentPage === 'function') {
+                    }).then((entry) => {
+                      if (entry && typeof renderConsentPage === 'function') {
                         renderConsentPage();
                       }
                     })


### PR DESCRIPTION
## Summary
Prevents consent Quick Templates from bypassing the legal attestation checkbox.
## Changes
- Added `recordTemplateConsent` gate that checks `confirm-legal`.
- Updated all template buttons to call the gate before recording.
- Kept existing consent log rendering behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced consent submission validation by requiring confirmation of legal attestation. Users attempting to submit consent preferences without checking the required legal confirmation checkbox will now see a warning message, and the submission will not proceed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->