### PR TITLE
fix: return 404 for unmatched routes instead of 200

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -36,4 +36,4 @@ class Default(WorkerEntrypoint):
         if hasattr(env, 'ASSETS'):
             return await env.ASSETS.fetch(request)
 
-        return Response('Asset server not configured')
+        return Response('Not Found', status=404)


### PR DESCRIPTION
## Summary

   - The fallback response in `src/main.py` returned HTTP 200 with body `'Asset server not
   configured'` for unknown paths
   - Changed to return `404 Not Found` which is the correct status for unmatched routes

   ## Test plan

   - [ ] Visit a non-existent route (e.g. `/nonexistent`) and verify 404 is returned
   - [ ] Verify existing routes (`/`, `/video-chat`, `/notes`, `/consent`) still return 200

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved HTTP error response handling: when accessing an unavailable resource without a configured asset server, the system now returns a proper 404 "Not Found" response instead of a non-standard error message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->