### PR TITLE
fix: sanitize caller name in consent modal to prevent XSS

### DIFF
--- a/public/js/video.js
+++ b/public/js/video.js
@@ -586,7 +586,8 @@ const VideoChat = (() => {
       .replace(/&/g, "&amp;")
       .replace(/</g, "&lt;")
       .replace(/>/g, "&gt;")
-      .replace(/"/g, "&quot;");
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#39;");
   }
 
   function askConsent(callerName) {


### PR DESCRIPTION
 ## Summary

  - The `callerName` parameter in `askConsent()` (`video.js`) was interpolated directly into
  `innerHTML` without escaping
  - A malicious peer could craft a peer ID containing HTML (e.g. `<img onerror=alert(1)>`) to execute
  arbitrary JavaScript in the victim's browser
  - Added `escHtml()` to sanitize the string before interpolation

  ## Test plan

  - [ ] Join a video chat and verify the consent modal still displays the caller name correctly
  - [ ] Confirm that a peer ID containing HTML characters (e.g. `<b>test</b>`) is displayed as literal
   text, not rendered as HTML

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced security in the consent modal by ensuring caller names are safely displayed, protecting against potential malicious input through participant identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->