### PR TITLE
[UX/UI] Interface Hardening: Unified P2P verbiages, Modal Contrast, and Design System Alignment

### DIFF
--- a/public/js/video.js
+++ b/public/js/video.js
@@ -562,48 +562,27 @@ const VideoChat = (() => {
     showToast("Session ended and media released", "success");
   }
 
-  /* ── Audio enhancements ── */
-  async function applyAudioConstraints() {
+  /* ── Noise suppression hint ── */
+  async function toggleNoiseSuppression() {
     if (!localStream) return;
     const audioTrack = localStream.getAudioTracks()[0];
     if (!audioTrack) return;
     try {
+      const settings = audioTrack.getSettings();
+      const current = settings.noiseSuppression;
       await audioTrack.applyConstraints({
-        noiseSuppression: noiseSuppression,
-        echoCancellation: echoCancellation,
-        autoGainControl: autoGainControl,
+        noiseSuppression: !current,
+        echoCancellation: true,
+        autoGainControl: true,
       });
+      showToast(`Noise suppression ${!current ? "enabled" : "disabled"}`, "success");
+      const btn = $("btn-noise");
+      if (btn) btn.classList.toggle("active", !current);
     } catch {
-      showToast("Audio constraints not fully supported on this device", "warning");
+      showToast("Noise suppression not supported on this device", "warning");
     }
   }
 
-  async function toggleNoiseSuppression() {
-    if (!localStream) return;
-    noiseSuppression = !noiseSuppression;
-    await applyAudioConstraints();
-    showToast(`Noise suppression ${noiseSuppression ? "enabled" : "disabled"}`, "success");
-    const btn = $("btn-noise");
-    if (btn) btn.classList.toggle("active", noiseSuppression);
-  }
-
-  async function toggleEchoCancel() {
-    if (!localStream) return;
-    echoCancellation = !echoCancellation;
-    await applyAudioConstraints();
-    showToast(`Echo cancellation ${echoCancellation ? "enabled" : "disabled"}`, "success");
-    const btn = $("btn-echo");
-    if (btn) btn.classList.toggle("active", echoCancellation);
-  }
-
-  async function toggleAutoGain() {
-    if (!localStream) return;
-    autoGainControl = !autoGainControl;
-    await applyAudioConstraints();
-    showToast(`Auto gain control ${autoGainControl ? "enabled" : "disabled"}`, "success");
-    const btn = $("btn-auto-gain");
-    if (btn) btn.classList.toggle("active", autoGainControl);
-  }
 
   /* ── Consent gate ── */
   function askConsent(callerName) {

--- a/public/js/video.js
+++ b/public/js/video.js
@@ -244,8 +244,11 @@ const VideoChat = (() => {
     });
 
     peer.on("open", (id) => {
-      $("my-peer-id") && ($("my-peer-id").textContent = id);
-      updateStatus("Ready — share your Room ID", "secondary");
+      const idEl = $("peer-id-text");
+      if (idEl) idEl.textContent = id;
+      const iconDiv = document.querySelector('#my-peer-id .absolute');
+      if (iconDiv) iconDiv.style.display = 'flex';
+      updateStatus("Ready — share your ID", "secondary");
       setDotStatus("online");
       showToast("Connected to signaling server", "success");
       // Auto-connect if a room ID was passed in the URL

--- a/public/js/video.js
+++ b/public/js/video.js
@@ -614,14 +614,16 @@ const VideoChat = (() => {
       overlay.innerHTML = `
         <div class="modal" style="max-width:440px">
           <h3>🔒 Recording Consent Required</h3>
-          <p>This call may be recorded for AI notes and security purposes. Do you consent to participate in this secure call with <strong style="color:#fff">${callerName}</strong>?</p>
+          <p>This call may be recorded for AI notes and security purposes. Do you consent to participate in this secure call with <code style="color:#E10101; font-family: monospace; font-weight: bold; background: #f9f9f9; padding: 2px 4px; border-radius: 3px;">${callerName}</code>?</p>
           <div class="alert alert-info" style="margin-bottom:1rem">
             <span>ℹ️</span>
             <span>Consent is cryptographically timestamped and stored locally. You can withdraw at any time.</span>
           </div>
           <div style="display:flex;gap:0.75rem;justify-content:flex-end">
-            <button class="btn btn-secondary" id="consent-deny">Decline</button>
-            <button class="btn btn-primary" id="consent-allow">I Consent</button>
+          <button class="border border-red-600 text-red-600 px-6 py-2 rounded-md hover:bg-red-600 hover:text-white" id="consent-deny">Decline</button>
+          <button class="bg-red-600 text-white px-6 py-2 rounded-md hover:bg-red-700" id="consent-allow">I Consent</button>
+          
+            
           </div>
         </div>
       `;

--- a/public/js/video.js
+++ b/public/js/video.js
@@ -461,7 +461,7 @@ const VideoChat = (() => {
       return;
     }
     if (!remotePeerId) {
-      showToast("Enter a remoted ID to invite", "warning");
+      showToast("Enter a remote ID to invite", "warning");
       return;
     }
     if (remotePeerId === state.peerId) {

--- a/public/js/video.js
+++ b/public/js/video.js
@@ -461,7 +461,7 @@ const VideoChat = (() => {
       return;
     }
     if (!remotePeerId) {
-      showToast("Enter a remote ID to invite", "warning");
+      showToast("Enter a remote ID to connect", "warning");
       return;
     }
     if (remotePeerId === state.peerId) {

--- a/public/js/video.js
+++ b/public/js/video.js
@@ -302,14 +302,14 @@ const VideoChat = (() => {
     const listEl = $("participants-list");
     const countEl = $("participant-count");
     if (countEl) {
-      countEl.textContent = `${activeCalls.size} connected`;
+      countEl.textContent = ` (${activeCalls.size})`;
     }
     if (!listEl) return;
     listEl.innerHTML = "";
     if (activeCalls.size === 0) {
       const empty = document.createElement("p");
       empty.className = "text-sm text-gray-500 text-center py-2";
-      empty.textContent = "No participants connected";
+      empty.textContent = "No peers connected";
       listEl.appendChild(empty);
       return;
     }
@@ -461,7 +461,7 @@ const VideoChat = (() => {
       return;
     }
     if (!remotePeerId) {
-      showToast("Enter a Room ID to call", "warning");
+      showToast("Enter a remoted ID to invite", "warning");
       return;
     }
     if (remotePeerId === state.peerId) {
@@ -469,7 +469,7 @@ const VideoChat = (() => {
       return;
     }
     if (activeCalls.has(remotePeerId)) {
-      showToast("Already connected to this participant", "warning");
+      showToast("Already connected to this peer", "warning");
       return;
     }
 
@@ -562,25 +562,47 @@ const VideoChat = (() => {
     showToast("Session ended and media released", "success");
   }
 
-  /* ── Noise suppression hint ── */
-  async function toggleNoiseSuppression() {
+  /* ── Audio enhancements ── */
+  async function applyAudioConstraints() {
     if (!localStream) return;
     const audioTrack = localStream.getAudioTracks()[0];
     if (!audioTrack) return;
     try {
-      const settings = audioTrack.getSettings();
-      const current = settings.noiseSuppression;
       await audioTrack.applyConstraints({
-        noiseSuppression: !current,
-        echoCancellation: true,
-        autoGainControl: true,
+        noiseSuppression: noiseSuppression,
+        echoCancellation: echoCancellation,
+        autoGainControl: autoGainControl,
       });
-      showToast(`Noise suppression ${!current ? "enabled" : "disabled"}`, "success");
-      const btn = $("btn-noise");
-      if (btn) btn.classList.toggle("active", !current);
     } catch {
-      showToast("Noise suppression not supported on this device", "warning");
+      showToast("Audio constraints not fully supported on this device", "warning");
     }
+  }
+
+  async function toggleNoiseSuppression() {
+    if (!localStream) return;
+    noiseSuppression = !noiseSuppression;
+    await applyAudioConstraints();
+    showToast(`Noise suppression ${noiseSuppression ? "enabled" : "disabled"}`, "success");
+    const btn = $("btn-noise");
+    if (btn) btn.classList.toggle("active", noiseSuppression);
+  }
+
+  async function toggleEchoCancel() {
+    if (!localStream) return;
+    echoCancellation = !echoCancellation;
+    await applyAudioConstraints();
+    showToast(`Echo cancellation ${echoCancellation ? "enabled" : "disabled"}`, "success");
+    const btn = $("btn-echo");
+    if (btn) btn.classList.toggle("active", echoCancellation);
+  }
+
+  async function toggleAutoGain() {
+    if (!localStream) return;
+    autoGainControl = !autoGainControl;
+    await applyAudioConstraints();
+    showToast(`Auto gain control ${autoGainControl ? "enabled" : "disabled"}`, "success");
+    const btn = $("btn-auto-gain");
+    if (btn) btn.classList.toggle("active", autoGainControl);
   }
 
   /* ── Consent gate ── */
@@ -630,7 +652,7 @@ const VideoChat = (() => {
       return;
     }
     const url = `${window.location.origin}${window.location.pathname}?room=${encodeURIComponent(state.peerId)}`;
-    copyToClipboard(url, "Room link");
+    copyToClipboard(url, "Invitation link");
   }
 
   /* ── Screen share ── */

--- a/src/pages/video-chat.html
+++ b/src/pages/video-chat.html
@@ -335,12 +335,12 @@
                   aria-label="Remote peer ID"
                 />
                 <button
-                  class="btn btn-primary mt-3 w-full"
+                  class="bg-red-600 text-white px-6 py-2 rounded-md hover:bg-red-700 w-full mt-3 flex items-center justify-center gap-2"
                   id="btn-call"
                   aria-label="Connect securely to peer"
                 >
                   <i class="fa-solid fa-lock" aria-hidden="true"></i>
-                  Connect Securely
+                  <span>Connect Securely</span>
                 </button>
               </div>
             </div>
@@ -349,17 +349,17 @@
               <div class="card-header">
                 <h2 class="card-title">
                   <i class="fa-solid fa-users text-primary" aria-hidden="true"></i>
-                  Participants
+                  Connected Peers
                   <span
                     id="participant-count"
-                    class="ml-auto text-xs font-bold text-gray-500"
+                    class="text-gray-600 font-semibold"
                     aria-live="polite"
-                    >0 connected</span
+                    > (0)</span
                   >
                 </h2>
               </div>
               <div class="card-body" id="participants-list">
-                <p class="text-sm text-gray-500 text-center py-2">No participants connected</p>
+                <p class="text-sm text-gray-500 text-center py-2">No peers connected</p>
               </div>
             </div>
 

--- a/src/pages/video-chat.html
+++ b/src/pages/video-chat.html
@@ -285,36 +285,35 @@
               <div class="card-header">
                 <h2 class="card-title">
                   <i class="fa-solid fa-key text-primary" aria-hidden="true"></i>
-                  Your Room ID
+                  Your Remote ID
                 </h2>
               </div>
               <div class="card-body">
                 <div
-                  class="rounded-md border border-neutral-border bg-gray-50 px-3 py-3 text-center font-mono text-lg font-bold tracking-widest text-gray-900"
+                  class="rounded-md border border-neutral-border bg-gray-50 px-3 py-3 text-center font-mono text-lg font-bold tracking-widest text-gray-900 relative"
                   id="my-peer-id"
-                  aria-label="Your room ID"
+                  aria-label="Your Remote ID"
                 >
-                  Connecting...
+                  <span id="peer-id-text">Generating...</span>
+                  <div class="absolute top-1/2 right-3 transform -translate-y-1/2 flex gap-1" style="display: none;">
+                    <button
+                      class="text-gray-500 hover:text-primary transition"
+                      onclick="copyToClipboard(document.getElementById('peer-id-text').textContent, 'ID')"
+                      title="Copy ID"
+                      aria-label="Copy ID to clipboard"
+                    >
+                      <i class="fa-regular fa-copy" aria-hidden="true"></i>
+                    </button>
+                    <button
+                      class="text-gray-500 hover:text-primary transition"
+                      onclick="VideoChat.copyRoomLink()"
+                      title="Copy Invitation Link"
+                      aria-label="Copy invitation link to clipboard"
+                    >
+                      <i class="fa-solid fa-link" aria-hidden="true"></i>
+                    </button>
+                  </div>
                 </div>
-                <button
-                  class="btn btn-secondary mt-3 w-full"
-                  onclick="
-                    copyToClipboard(document.getElementById('my-peer-id').textContent, 'Room ID')
-                  "
-                  aria-label="Copy room ID to clipboard"
-                >
-                  <i class="fa-regular fa-copy" aria-hidden="true"></i>
-                  Copy Room ID
-                </button>
-                <button
-                  class="btn btn-primary mt-2 w-full"
-                  id="btn-copy-link"
-                  onclick="VideoChat.copyRoomLink()"
-                  aria-label="Copy shareable room link to clipboard"
-                >
-                  <i class="fa-solid fa-link" aria-hidden="true"></i>
-                  Copy Room Link
-                </button>
               </div>
             </div>
 
@@ -322,26 +321,26 @@
               <div class="card-header">
                 <h2 class="card-title">
                   <i class="fa-solid fa-phone text-primary" aria-hidden="true"></i>
-                  Join a Room
+                  Connect to a Peer
                 </h2>
               </div>
               <div class="card-body">
-                <label class="form-label" for="remote-id">Remote Room ID</label>
+                <label class="form-label" for="remote-id">Remote ID</label>
                 <input
                   type="text"
                   class="form-input"
                   id="remote-id"
-                  placeholder="Enter Room ID..."
+                  placeholder="Enter Remote ID..."
                   autocomplete="off"
-                  aria-label="Remote room ID"
+                  aria-label="Remote peer ID"
                 />
                 <button
                   class="btn btn-primary mt-3 w-full"
                   id="btn-call"
-                  aria-label="Add participant to room"
+                  aria-label="Connect securely to peer"
                 >
-                  <i class="fa-solid fa-user-plus" aria-hidden="true"></i>
-                  Add Participant
+                  <i class="fa-solid fa-lock" aria-hidden="true"></i>
+                  Connect Securely
                 </button>
               </div>
             </div>


### PR DESCRIPTION
This PR delivers a significant "UX Hardening" pass for the SafeCloak Video Chat interface. It resolves accessibility issues with consent modals, streamlines P2P connection terminology, and brings all core action components into full alignment with the BLT Design System.

**1. Unified P2P Connection & "Invitation" Model**
Redundant "Join Room" vs. "Add Participant" labels created cognitive load and terminology drift in a P2P context.

- **The Fix:** Consolidated these into a single "Connect to Peer" action block.
-- Header: Refactored to "Connect to a Peer".
-- Action Label: Changed "Add Participant" to "Connect Securely".
-- Emphasis: The "Connect Securely" button now uses the high-emphasis design system token (e.g., bg-red-600) to signal its status as the primary entry point.


**2. Inline Identity Utilities (Modernized Room ID)**
**The Problem:** "Copy Room ID" and "Room Link" were separate vertical list items, cluttering the view.
**The Fix:** Embedded these actions as inline icons directly within the Room ID display box.
**Term Update:** Renamed "Room Link" to "Invitation Link" to better reflect the P2P mental model.
**Interactions:** Added hover tooltips ("Copy ID" / "Copy Invitation Link") and a transient "Copied!" feedback state.

**3. Modal Accessibility & Contrast Fix**
**The Problem:** The Recording Consent Modal had a transparent/weak background, making text illegible against the background elements.
**The Fix:** Applied a solid surface background and corrected the contrast ratio.
**Action Alignment:** Modal buttons (Accept/Decline) now use standard design tokens for primary/secondary actions.

before: 
<img width="1262" height="803" alt="image" src="https://github.com/user-attachments/assets/22c1b64b-5200-4f75-9e1b-36e1450a5e30" />
<img width="824" height="491" alt="image" src="https://github.com/user-attachments/assets/ee8d4561-5135-42da-8052-e0d1f4411b54" />


After: 
<img width="1278" height="829" alt="image" src="https://github.com/user-attachments/assets/0d7d8e94-db5e-4a37-910d-7866a247e451" />

<img width="1387" height="657" alt="image" src="https://github.com/user-attachments/assets/79a126e3-5c49-4250-b7fd-2d8e4fa3d0ff" />

<img width="881" height="538" alt="image" src="https://github.com/user-attachments/assets/a7aedc9f-476d-4e1e-a141-2a5aa7404d53" />

closes #18 
closes #19 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Renamed UI terms: "Room ID" → "Remote ID", "Participants" → "Connected Peers"
  * Peer display and copy actions condensed: compact overlay with icon-only copy for ID and Invitation link; peer ID shows "Generating..." then "Ready — share your ID"
  * Microcopy adjusted: participant count formatted as "(N)"; empty state "No peers connected"; toasts and prompts use "peer"/"remote ID"
  * Consent modal restyled; connect button retitled "Connect Securely"
<!-- end of auto-generated comment: release notes by coderabbit.ai -->