### PR TITLE
Fix screen share toggle

### DIFF
--- a/public/js/video.js
+++ b/public/js/video.js
@@ -675,6 +675,15 @@ const VideoChat = (() => {
     showToast("Screen sharing stopped", "info");
   }
 
+  function toggleScreenShare() {
+    console.log("toggleScreenshare: ", screenSharing);
+    if (screenSharing) {
+      stopScreenShare();
+    } else {
+      shareScreen();
+    }
+  }
+
   /* ── Init ── */
   async function init() {
     const ok = await startLocalMedia();
@@ -692,6 +701,7 @@ const VideoChat = (() => {
     toggleNoiseSuppression,
     shareScreen,
     stopScreenShare,
+    toggleScreenShare,
     copyRoomLink,
     state,
   };

--- a/public/js/video.js
+++ b/public/js/video.js
@@ -676,7 +676,6 @@ const VideoChat = (() => {
   }
 
   function toggleScreenShare() {
-    console.log("toggleScreenshare: ", screenSharing);
     if (screenSharing) {
       stopScreenShare();
     } else {

--- a/public/js/video.js
+++ b/public/js/video.js
@@ -15,6 +15,8 @@ const VideoChat = (() => {
   let camOff = false;
   let consentGiven = false;
   let screenSharing = false;
+  let currentScreenStream = null;
+  let screenShareBusy = false;
 
   const state = {
     peerId: null,
@@ -633,8 +635,8 @@ const VideoChat = (() => {
   /* ── Screen share ── */
   async function shareScreen() {
     try {
-      const screenStream = await navigator.mediaDevices.getDisplayMedia({ video: true });
-      const screenTrack = screenStream.getVideoTracks()[0];
+      currentScreenStream = await navigator.mediaDevices.getDisplayMedia({ video: true });
+      const screenTrack = currentScreenStream.getVideoTracks()[0];
       for (const call of activeCalls.values()) {
         if (call.peerConnection) {
           const sender = call.peerConnection
@@ -644,7 +646,7 @@ const VideoChat = (() => {
         }
       }
       const localVideo = $("local-video");
-      if (localVideo) localVideo.srcObject = screenStream;
+      if (localVideo) localVideo.srcObject = currentScreenStream;
       showToast("Screen sharing started", "success");
       screenSharing = true;
       $("btn-screen") && $("btn-screen").classList.add("active");
@@ -657,29 +659,37 @@ const VideoChat = (() => {
   }
 
   function stopScreenShare() {
-    if (!localStream || activeCalls.size === 0) return;
-    const videoTrack = localStream.getVideoTracks()[0];
-    if (!videoTrack) return;
-    for (const call of activeCalls.values()) {
-      const sender =
-        call.peerConnection &&
-        call.peerConnection.getSenders().find((s) => s.track && s.track.kind === "video");
-      if (sender) sender.replaceTrack(videoTrack);
+    if (currentScreenStream) {
+      currentScreenStream.getTracks().forEach((t) => t.stop());
+      currentScreenStream = null;
+    }
+    const videoTrack = localStream?.getVideoTracks?.()[0];
+    if (videoTrack) {
+      for (const call of activeCalls.values()) {
+        const sender =
+          call.peerConnection &&
+          call.peerConnection.getSenders().find((s) => s.track && s.track.kind === "video");
+        if (sender) sender.replaceTrack(videoTrack);
+      }
     }
     const localVideo = $("local-video");
-    if (localVideo) {
-      localVideo.srcObject = localStream;
-    }
+    if (localVideo && localStream) localVideo.srcObject = localStream;
     $("btn-screen") && $("btn-screen").classList.remove("active");
     screenSharing = false;
     showToast("Screen sharing stopped", "info");
   }
 
-  function toggleScreenShare() {
-    if (screenSharing) {
-      stopScreenShare();
-    } else {
-      shareScreen();
+  async function toggleScreenShare() {
+    if (screenShareBusy) return;
+    screenShareBusy = true;
+    try {
+      if (screenSharing) {
+        stopScreenShare();
+      } else {
+        await shareScreen();
+      }
+    } finally {
+      screenShareBusy = false;
     }
   }
 

--- a/public/js/video.js
+++ b/public/js/video.js
@@ -544,6 +544,9 @@ const VideoChat = (() => {
   }
 
   function hangup() {
+    if (screenSharing || currentScreenStream) {
+      stopScreenShare();
+    }
     endCall();
     if (peer) {
       peer.disconnect();

--- a/public/js/video.js
+++ b/public/js/video.js
@@ -668,11 +668,22 @@ const VideoChat = (() => {
     }
     const videoTrack = localStream?.getVideoTracks?.()[0];
     if (videoTrack) {
+      const replacePromises = [];
       for (const call of activeCalls.values()) {
         const sender =
           call.peerConnection &&
           call.peerConnection.getSenders().find((s) => s.track && s.track.kind === "video");
-        if (sender) sender.replaceTrack(videoTrack);
+        if (sender) {
+          replacePromises.push(sender.replaceTrack(videoTrack));
+        }
+      }
+      if (replacePromises.length) {
+        Promise.allSettled(replacePromises).then((results) => {
+          const failures = results.filter((r) => r.status === "rejected");
+          if (failures.length) {
+            console.error("Failed to restore camera track for some peers", failures);
+          }
+        });
       }
     }
     const localVideo = $("local-video");

--- a/src/pages/video-chat.html
+++ b/src/pages/video-chat.html
@@ -238,7 +238,7 @@
                 class="control-btn"
                 id="btn-screen"
                 title="Share screen"
-                onclick="VideoChat.shareScreen()"
+                onclick="VideoChat.toggleScreenShare()"
                 aria-label="Share screen"
               >
                 <i class="fa-solid fa-display" aria-hidden="true"></i>


### PR DESCRIPTION
Previously, the Share Screen button on /video-chat could only start screen sharing and didn’t allow stopping or toggling, it had to be stopped from the browser popup.

I added a `toggleScreenShare` function that uses the existing `shareScreen` and `stopScreenShare` methods, so the button now properly toggles between starting and stopping screen sharing, making the experience much more intuitive.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Single-toggle screen sharing control to start/stop capture; prevents concurrent toggles.

* **Bug Fixes**
  * Ending a call now also stops screen sharing automatically.
  * Restores outbound camera video and local preview reliably after stopping screen share.
  * Improved robustness when switching between camera and screen to avoid stale streams.

* **UI**
  * Screen-share button now uses the new toggle behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->