### PR TITLE
Fix anchor scroll offset for "How It Works" section

### DIFF
--- a/src/pages/index.html
+++ b/src/pages/index.html
@@ -402,7 +402,7 @@
       <section class="px-4 pb-14 sm:px-6 lg:px-8" aria-labelledby="how-heading">
         <div class="mx-auto max-w-6xl">
           <h2
-            class="text-center text-3xl font-extrabold text-gray-900 sm:text-4xl"
+            class="text-center text-3xl font-extrabold text-gray-900 sm:text-4xl scroll-mt-20"
             id="how-heading"
           >
             How It Works


### PR DESCRIPTION
## Summary
Fixes an issue where clicking "How It Works" scrolls the section heading under the sticky navbar.

## Before
When clicking "How It Works", the page scrolled such that the section heading was hidden under the sticky navbar.
![Before](https://github.com/user-attachments/assets/2553d7ae-8b81-45e7-8f82-897bedab3a2d)

## After
Clicking "How It Works" now correctly positions the section heading fully visible below the navbar.
![After](https://github.com/user-attachments/assets/6cbfd148-b726-46e0-b50a-358216a726c2)

## Changes
- Added scroll margin to the target section heading to offset sticky navbar height

## Result
- Heading is fully visible after navigation
- Improved in-page navigation UX

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scroll positioning when navigating to the "How It Works" section via anchor links to ensure proper visibility with sticky layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->