### PR TITLE
Improve URL join handling to prevent invalid peer initialization

### DIFF
--- a/public/js/video.js
+++ b/public/js/video.js
@@ -250,13 +250,18 @@ const VideoChat = (() => {
       showToast("Connected to signaling server", "success");
       // Auto-connect if a room ID was passed in the URL
       const params = new URLSearchParams(window.location.search);
-      const joinId = params.get("room");
-      if (joinId && joinId !== state.peerId) {
+      const joinIdRaw = params.get("room");
+      if (joinIdRaw && isValidRoomId(joinIdRaw)) {
+        const joinId = joinIdRaw.trim();
+      if (joinId !== state.peerId) {
         const remoteInput = $("remote-id");
         if (remoteInput) {
           remoteInput.value = joinId;
         }
         callPeer(joinId);
+      }
+      } else if (joinIdRaw) {
+        showToast("Invalid Room ID","error");
       }
     });
 


### PR DESCRIPTION
## Issue
The auto-connect flow accepts the `room` parameter directly from the URL and attempts to initiate a peer connection without verifying its format. This can lead to malformed inputs reaching the connection layer and triggering unnecessary or unintended behavior.

## Fix
Introduced a guard in the auto-connect flow to ensure only well-formed room IDs are processed before initiating a connection.

- Ensures only valid room IDs reach the connection logic
- Prevents unnecessary execution of peer connection flow
- Avoids unintended UI updates from malformed input

## Impact
- Improves stability of the auto-connect mechanism
- Prevents invalid peer initialization attempts
- Aligns URL-driven flows with existing input constraints

## Testing
- Valid room ID → auto-connect works as expected
- Invalid room ID → connection is not attempted and error is shown

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved URL-based room auto-join with validation; invalid room IDs now display an error message instead of being silently ignored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->