### PR TITLE
fix(video): use Font Awesome icon classes for mic/camera toggle

### DIFF
--- a/public/js/video.js
+++ b/public/js/video.js
@@ -530,7 +530,8 @@ const VideoChat = (() => {
     localStream.getVideoTracks().forEach((t) => (t.enabled = !camOff));
     const btn = $("btn-cam");
     if (btn) {
-      btn.textContent = camOff ? "📷" : "🎥";
+      const icon = btn.querySelector("i");
+      if (icon) icon.className = camOff ? "fa-solid fa-video-slash" : "fa-solid fa-video";
       btn.title = camOff ? "Enable camera" : "Disable camera";
       btn.classList.toggle("active", camOff);
     }


### PR DESCRIPTION
## Summary

  - `toggleMic()` and `toggleCamera()` used `btn.textContent` to set emoji strings, which destroyed the Font Awesome `<i>`
  element inside the button
  - After the first toggle the icon was permanently replaced with emoji text, breaking visual consistency with the rest of the
   UI
  - Now toggles the `<i>` element's class between the appropriate Font Awesome icons (`fa-microphone`/`fa-microphone-slash`,
  `fa-video`/`fa-video-slash`)

  ## Test plan

  - [ ] Click the mic toggle button — icon should switch between microphone and microphone-slash
  - [ ] Click the camera toggle button — icon should switch between video and video-slash
  - [ ] Toggle multiple times — icon should remain a Font Awesome icon, never replaced by emoji

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated microphone and camera toggle button icon display for visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->