### PR TITLE
Delayed Media Permissions

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -116,39 +116,6 @@ body {
    ============================================ */
 
 /* === Status Indicators === */
-.status-dot {
-  width: 8px;
-  height: 8px;
-  border-radius: 9999px;
-  display: inline-block;
-  flex-shrink: 0;
-}
-
-.status-dot.online {
-  background: #16a34a;
-  box-shadow: 0 0 0 2px rgba(22, 163, 74, 0.2);
-}
-
-.status-dot.offline {
-  background: #9ca3af;
-}
-
-.status-dot.connecting {
-  background: #f59e0b;
-  animation: pulse-dot 1.4s infinite;
-}
-
-@keyframes pulse-dot {
-  0%,
-  100% {
-    opacity: 1;
-  }
-
-  50% {
-    opacity: 0.45;
-  }
-}
-
 /* === Video Grid (multi-participant) === */
 .video-grid {
   display: grid;

--- a/public/js/video.js
+++ b/public/js/video.js
@@ -12,8 +12,8 @@ const VideoChat = (() => {
   let audioContext = null;
   let analyser = null;
   let voiceAnimFrame = null;
-  let micMuted = false;
-  let camOff = false;
+  let micMuted = true;
+  let camOff = true;
   let consentGiven = false;
   let screenSharing = false;
   let initialMediaPreferences = { mic: true, cam: true };
@@ -608,96 +608,122 @@ const VideoChat = (() => {
     broadcastProfile(true);
   }
 
+  let mediaPromise = null;
+
   async function startLocalMedia() {
-    // 1. Try full video + audio
-    try {
-      localStream = await navigator.mediaDevices.getUserMedia({ video: true, audio: true });
-      await attachStream(localStream);
-      applyInitialMediaPreferences();
-      return true;
-    } catch (err) {
-      if (
-        err.name === "NotAllowedError" ||
-        err.name === "PermissionDeniedError" ||
-        err.name === "SecurityError"
-      ) {
-        showCameraDenied();
-        return false;
+    if (mediaPromise) return mediaPromise;
+    mediaPromise = (async () => {
+      // 1. Try full video + audio
+      try {
+        localStream = await navigator.mediaDevices.getUserMedia({
+          video: true,
+          audio: true,
+        });
+        await attachStream(localStream);
+        applyInitialMediaPreferences();
+        return true;
+      } catch (err) {
+        if (
+          err.name === "NotAllowedError" ||
+          err.name === "PermissionDeniedError" ||
+          err.name === "SecurityError"
+        ) {
+          showCameraDenied();
+          return false;
+        }
+
+        if (err.name === "NotReadableError" || err.name === "TrackStartError") {
+          showToast(
+            "Camera or microphone is already in use by another application. Please close it and reload.",
+            "error"
+          );
+          return false;
+        }
+
+        // For NotFoundError / DevicesNotFoundError try partial fallbacks below.
+        if (err.name !== "NotFoundError" && err.name !== "DevicesNotFoundError") {
+          showToast("Could not access camera/microphone: " + err.message, "error");
+          return false;
+        }
       }
 
-      if (err.name === "NotReadableError" || err.name === "TrackStartError") {
-        showToast(
-          "Camera or microphone is already in use by another application. Please close it and reload.",
-          "error"
-        );
-        return false;
+      // 2. No combined device found — try audio-only
+      try {
+        localStream = await navigator.mediaDevices.getUserMedia({
+          video: false,
+          audio: true,
+        });
+        await attachStream(localStream);
+        applyInitialMediaPreferences();
+        showToast("No camera found — joining with audio only", "warning");
+        return true;
+      } catch (audioErr) {
+        if (
+          audioErr.name === "NotAllowedError" ||
+          audioErr.name === "PermissionDeniedError" ||
+          audioErr.name === "SecurityError"
+        ) {
+          showCameraDenied();
+          return false;
+        }
+        if (
+          audioErr.name !== "NotFoundError" &&
+          audioErr.name !== "DevicesNotFoundError"
+        ) {
+          showToast("Could not access microphone: " + audioErr.message, "error");
+          return false;
+        }
       }
 
-      // For NotFoundError / DevicesNotFoundError try partial fallbacks below.
-      // For any other unexpected error fall through to the generic handler at the end.
-      if (err.name !== "NotFoundError" && err.name !== "DevicesNotFoundError") {
-        showToast("Could not access camera/microphone: " + err.message, "error");
-        return false;
+      // 3. No microphone either — try video-only
+      try {
+        localStream = await navigator.mediaDevices.getUserMedia({
+          video: true,
+          audio: false,
+        });
+        await attachStream(localStream);
+        applyInitialMediaPreferences();
+        showToast("No microphone found — joining with video only", "warning");
+        return true;
+      } catch (videoErr) {
+        if (
+          videoErr.name === "NotAllowedError" ||
+          videoErr.name === "PermissionDeniedError" ||
+          videoErr.name === "SecurityError"
+        ) {
+          showCameraDenied();
+          return false;
+        }
+        if (
+          videoErr.name === "NotReadableError" ||
+          videoErr.name === "TrackStartError"
+        ) {
+          showToast(
+            "Camera is already in use by another application. Please close it and reload.",
+            "error"
+          );
+          return false;
+        }
+        if (
+          videoErr.name !== "NotFoundError" &&
+          videoErr.name !== "DevicesNotFoundError"
+        ) {
+          showToast("Could not access camera: " + videoErr.message, "error");
+          return false;
+        }
       }
-    }
 
-    // 2. No combined device found — try audio-only
-    try {
-      localStream = await navigator.mediaDevices.getUserMedia({ video: false, audio: true });
-      await attachStream(localStream);
-      applyInitialMediaPreferences();
-      showToast("No camera found — joining with audio only", "warning");
-      return true;
-    } catch (audioErr) {
-      if (
-        audioErr.name === "NotAllowedError" ||
-        audioErr.name === "PermissionDeniedError" ||
-        audioErr.name === "SecurityError"
-      ) {
-        showCameraDenied();
-        return false;
-      }
-      if (audioErr.name !== "NotFoundError" && audioErr.name !== "DevicesNotFoundError") {
-        showToast("Could not access microphone: " + audioErr.message, "error");
-        return false;
-      }
-    }
+      // 4. No devices at all
+      showToast(
+        "No camera or microphone found. Please connect a device and try reloading the page.",
+        "error"
+      );
+      return false;
+    })();
 
-    // 3. No microphone either — try video-only
-    try {
-      localStream = await navigator.mediaDevices.getUserMedia({ video: true, audio: false });
-      await attachStream(localStream);
-      applyInitialMediaPreferences();
-      showToast("No microphone found — joining with video only", "warning");
-      return true;
-    } catch (videoErr) {
-      if (
-        videoErr.name === "NotAllowedError" ||
-        videoErr.name === "PermissionDeniedError" ||
-        videoErr.name === "SecurityError"
-      ) {
-        showCameraDenied();
-        return false;
-      }
-      if (videoErr.name === "NotReadableError" || videoErr.name === "TrackStartError") {
-        showToast(
-          "Camera is already in use by another application. Please close it and reload.",
-          "error"
-        );
-        return false;
-      }
-      if (videoErr.name !== "NotFoundError" && videoErr.name !== "DevicesNotFoundError") {
-        showToast("Could not access camera: " + videoErr.message, "error");
-        return false;
-      }
-    }
-
-    // 4. No devices at all
-    showToast(
-      "No camera or microphone found. Please connect a device and try reloading the page.",
-      "error"
-    );
-    return false;
+    const result = await mediaPromise;
+    if (!result) mediaPromise = null; // Allow retry if it failed
+    return result;
   }
 
   function startVoiceMeter(stream) {
@@ -804,7 +830,22 @@ const VideoChat = (() => {
       }
       activeCalls.set(incomingCall.peer, incomingCall);
       updateParticipantsList();
+<<<<<<< HEAD
       incomingCall.answer(voiceStream || localStream);
+=======
+
+      if (!localStream) {
+        micMuted = false;
+        camOff = false;
+        const ok = await startLocalMedia();
+        if (!ok) {
+          incomingCall.close();
+          return;
+        }
+      }
+
+      incomingCall.answer(localStream);
+>>>>>>> 747222e (Delayed Media Permissions)
       handleCallStream(incomingCall);
       ensureDataConn(incomingCall.peer);
       sendPeerListTo(incomingCall.peer);
@@ -903,6 +944,15 @@ const VideoChat = (() => {
         "success"
       );
       setDotStatus("online");
+<<<<<<< HEAD
+=======
+      if ($("call-controls")) {
+        $("call-controls").classList.remove("hidden");
+        $("btn-noise") && $("btn-noise").classList.remove("hidden");
+        $("btn-screen") && $("btn-screen").classList.remove("hidden");
+        $("btn-end") && $("btn-end").classList.remove("hidden");
+      }
+>>>>>>> 747222e (Delayed Media Permissions)
       updateParticipantsList();
       sendProfileTo(remotePeerId, true);
     });
@@ -926,6 +976,14 @@ const VideoChat = (() => {
         state.connected = false;
         updateStatus("Call ended", "muted");
         setDotStatus("offline");
+<<<<<<< HEAD
+=======
+        if ($("call-controls")) {
+          $("btn-noise") && $("btn-noise").classList.add("hidden");
+          $("btn-screen") && $("btn-screen").classList.add("hidden");
+          $("btn-end") && $("btn-end").classList.add("hidden");
+        }
+>>>>>>> 747222e (Delayed Media Permissions)
       } else {
         const count = activeCalls.size;
         updateStatus(
@@ -1013,8 +1071,11 @@ const VideoChat = (() => {
       return;
     }
     if (!localStream) {
-      showToast("No local stream — allow camera/mic first", "error");
-      return;
+      // If joining a call directly, enable both by default
+      micMuted = false;
+      camOff = false;
+      const ok = await startLocalMedia();
+      if (!ok) return;
     }
     if (!remotePeerId) {
       showToast("Enter a Room ID to call", "warning");
@@ -1066,30 +1127,36 @@ const VideoChat = (() => {
   }
 
   /* ── Controls ── */
-  function toggleMic() {
-    if (!localStream) return;
-    if (localStream.getAudioTracks().length === 0) {
-      showToast("No microphone available", "warning");
-      return;
+  async function toggleMic() {
+    micMuted = !micMuted;
+    if (!localStream) {
+      const ok = await startLocalMedia();
+      if (!ok) {
+        micMuted = true; // reset state
+        return;
+      }
+    } else {
+      localStream.getAudioTracks().forEach((t) => (t.enabled = !micMuted));
     }
 
-    micMuted = !micMuted;
-    localStream.getAudioTracks().forEach((track) => (track.enabled = !micMuted));
     syncControlButtons();
     updateLocalTilePresentation();
     broadcastProfile(true);
     showToast(micMuted ? "Microphone muted" : "Microphone unmuted", "info");
   }
 
-  function toggleCamera() {
-    if (!localStream) return;
-    if (localStream.getVideoTracks().length === 0) {
-      showToast("No camera available", "warning");
-      return;
+  async function toggleCamera() {
+    camOff = !camOff;
+    if (!localStream) {
+      const ok = await startLocalMedia();
+      if (!ok) {
+        camOff = true; // reset state
+        return;
+      }
+    } else {
+      localStream.getVideoTracks().forEach((t) => (t.enabled = !camOff));
     }
 
-    camOff = !camOff;
-    localStream.getVideoTracks().forEach((track) => (track.enabled = !camOff));
     syncControlButtons();
     updateLocalTilePresentation();
     broadcastProfile(true);
@@ -1121,6 +1188,11 @@ const VideoChat = (() => {
       videoGrid.querySelectorAll(".video-wrapper:not(:first-child)").forEach((w) => w.remove());
     }
     updateLocalTilePresentation();
+    if ($("call-controls")) {
+      $("btn-noise") && $("btn-noise").classList.add("hidden");
+      $("btn-screen") && $("btn-screen").classList.add("hidden");
+      $("btn-end") && $("btn-end").classList.add("hidden");
+    }
     updateParticipantsList();
     showToast("Call ended", "info");
     // Record consent end
@@ -1638,20 +1710,22 @@ const VideoChat = (() => {
   }
 
   /* ── Init ── */
-  async function init() {
     state.displayName = resolveDisplayName();
     state.displayInitials = makeInitials(state.displayName);
 
     readInitialMediaPreferencesFromUrl();
     updateLocalTilePresentation();
+    
+    // We try to start media immediately if we have preferences from the lobby
     const ok = await startLocalMedia();
     if (ok) {
       updateLocalTilePresentation();
       _applyStoredVoicePreferences();
-      await initPeer();
     }
-    return ok;
-  }
+    
+    // Always init peer regardless of success of startLocalMedia (can join without media)
+    await initPeer();
+    return true;
 
   return {
     init,

--- a/public/js/video.js
+++ b/public/js/video.js
@@ -42,10 +42,18 @@ const VideoChat = (() => {
   /* ── DOM helpers ── */
   const $ = (id) => document.getElementById(id);
 
-  function updateStatus(text, type = "muted") {
+  function updateStatus(iconClass, text, type = "muted") {
     const el = $("connection-status");
     if (!el) return;
-    el.innerHTML = text;
+    el.innerHTML = "";
+    if (iconClass) {
+      const icon = document.createElement("i");
+      icon.className = iconClass + " mr-1";
+      icon.setAttribute("aria-hidden", "true");
+      el.appendChild(icon);
+    }
+    const textNode = document.createTextNode(text);
+    el.appendChild(textNode);
     el.className = `text-${type}`;
   }
 
@@ -629,34 +637,9 @@ const VideoChat = (() => {
     if (mediaPromise) return mediaPromise;
     mediaPromise = (async () => {
       try {
-<<<<<<< HEAD
-        localStream = await navigator.mediaDevices.getUserMedia({
-          video: true,
-          audio: true,
-        });
+        localStream = await navigator.mediaDevices.getUserMedia(constraints);
         await attachStream(localStream);
         applyInitialMediaPreferences();
-=======
-        const stream = await navigator.mediaDevices.getUserMedia(constraints);
-        const ls = await ensureLocalStream();
-
-        if (constraints.audio) {
-          stream.getAudioTracks().forEach((t) => {
-            t.enabled = !micMuted;
-            ls.addTrack(t);
-            updateTracksInCalls(t, "audio");
-          });
-        }
-        if (constraints.video) {
-          stream.getVideoTracks().forEach((t) => {
-            t.enabled = !camOff;
-            ls.addTrack(t);
-            updateTracksInCalls(t, "video");
-            const localVideo = $("local-video");
-            if (localVideo) localVideo.srcObject = ls;
-          });
-        }
->>>>>>> bf0030e (fix toggle)
         return true;
       } catch (err) {
         if (
@@ -670,82 +653,6 @@ const VideoChat = (() => {
         showToast("Access error: " + err.message, "error");
         return false;
       }
-<<<<<<< HEAD
-
-      // 2. No combined device found — try audio-only
-      try {
-        localStream = await navigator.mediaDevices.getUserMedia({
-          video: false,
-          audio: true,
-        });
-        await attachStream(localStream);
-        applyInitialMediaPreferences();
-        showToast("No camera found — joining with audio only", "warning");
-        return true;
-      } catch (audioErr) {
-        if (
-          audioErr.name === "NotAllowedError" ||
-          audioErr.name === "PermissionDeniedError" ||
-          audioErr.name === "SecurityError"
-        ) {
-          showCameraDenied();
-          return false;
-        }
-        if (
-          audioErr.name !== "NotFoundError" &&
-          audioErr.name !== "DevicesNotFoundError"
-        ) {
-          showToast("Could not access microphone: " + audioErr.message, "error");
-          return false;
-        }
-      }
-
-      // 3. No microphone either — try video-only
-      try {
-        localStream = await navigator.mediaDevices.getUserMedia({
-          video: true,
-          audio: false,
-        });
-        await attachStream(localStream);
-        applyInitialMediaPreferences();
-        showToast("No microphone found — joining with video only", "warning");
-        return true;
-      } catch (videoErr) {
-        if (
-          videoErr.name === "NotAllowedError" ||
-          videoErr.name === "PermissionDeniedError" ||
-          videoErr.name === "SecurityError"
-        ) {
-          showCameraDenied();
-          return false;
-        }
-        if (
-          videoErr.name === "NotReadableError" ||
-          videoErr.name === "TrackStartError"
-        ) {
-          showToast(
-            "Camera is already in use by another application. Please close it and reload.",
-            "error"
-          );
-          return false;
-        }
-        if (
-          videoErr.name !== "NotFoundError" &&
-          videoErr.name !== "DevicesNotFoundError"
-        ) {
-          showToast("Could not access camera: " + videoErr.message, "error");
-          return false;
-        }
-      }
-
-      // 4. No devices at all
-      showToast(
-        "No camera or microphone found. Please connect a device and try reloading the page.",
-        "error"
-      );
-      return false;
-=======
->>>>>>> bf0030e (fix toggle)
     })();
 
     const result = await mediaPromise;
@@ -754,6 +661,7 @@ const VideoChat = (() => {
   }
 
   function startVoiceMeter(stream) {
+    if (audioContext || stream.getAudioTracks().length === 0) return;
     try {
       if (voiceAnimFrame) {
         cancelAnimationFrame(voiceAnimFrame);
@@ -827,14 +735,9 @@ const VideoChat = (() => {
 
     peer.on("open", (id) => {
       $("my-peer-id") && ($("my-peer-id").textContent = id);
-<<<<<<< HEAD
-      updateStatus("Ready — share your Room ID", "secondary");
-      setDotStatus("online");
-      updateLocalTilePresentation();
-=======
-      updateStatus(`<i class="fa-solid fa-share-nodes mr-1"></i> Ready — share your Room ID`, "secondary");
+      updateStatus("fa-solid fa-share-nodes", "Ready — share your Room ID", "secondary");
       setStatusIcon("online");
->>>>>>> bf0030e (fix toggle)
+      updateLocalTilePresentation();
       showToast("Connected to signaling server", "success");
       // Populate room ID if passed in URL, but wait for user to click "Add Participant"
       const params = new URLSearchParams(window.location.search);
@@ -862,30 +765,18 @@ const VideoChat = (() => {
       }
       activeCalls.set(incomingCall.peer, incomingCall);
       updateParticipantsList();
-<<<<<<< HEAD
-      incomingCall.answer(voiceStream || localStream);
-=======
-
-<<<<<<< HEAD
-      if (!localStream) {
-        micMuted = false;
-        camOff = false;
-        const ok = await startLocalMedia();
-        if (!ok) {
-          incomingCall.close();
-          return;
-        }
-      }
-
-      incomingCall.answer(localStream);
->>>>>>> 747222e (Delayed Media Permissions)
-=======
-      const ls = await ensureLocalStream();
+      
       micMuted = false;
       camOff = false;
       updateMediaButtons();
-      incomingCall.answer(ls);
->>>>>>> bf0030e (fix toggle)
+      
+      const ok = await startLocalMedia();
+      if (!ok) {
+        incomingCall.close();
+        return;
+      }
+      
+      incomingCall.answer(voiceStream || localStream);
       handleCallStream(incomingCall);
       ensureDataConn(incomingCall.peer);
       sendPeerListTo(incomingCall.peer);
@@ -896,13 +787,13 @@ const VideoChat = (() => {
     });
 
     peer.on("error", (err) => {
-      updateStatus(`<i class="fa-solid fa-circle-exclamation mr-1"></i> Error: ` + err.message, "danger");
+      updateStatus("fa-solid fa-circle-exclamation", "Error: " + err.message, "danger");
       setStatusIcon("offline");
       showToast("Connection error: " + err.type, "error");
     });
 
     peer.on("disconnected", () => {
-      updateStatus(`<i class="fa-solid fa-plug-circle-xmark mr-1"></i> Disconnected`, "warning");
+      updateStatus("fa-solid fa-plug-circle-xmark", "Disconnected", "warning");
       setStatusIcon("offline");
     });
   }
@@ -967,7 +858,6 @@ const VideoChat = (() => {
 
   function handleCallStream(call) {
     const remotePeerId = call.peer;
-<<<<<<< HEAD
     const tile = ensureRemoteTile(remotePeerId);
     const videoEl = tile ? tile.video : null;
     updateTilePresentation(remotePeerId);
@@ -978,65 +868,20 @@ const VideoChat = (() => {
       }
       attachRemoteSpeakingMonitor(remotePeerId, remoteStream);
       updateTilePresentation(remotePeerId);
-=======
-
-    const videoWrapper = document.createElement("div");
-    videoWrapper.className = "video-wrapper bg-gray-900";
-    videoWrapper.id = `wrapper-${remotePeerId}`;
-
-    const videoEl = document.createElement("video");
-    videoEl.autoplay = true;
-    videoEl.playsInline = true;
-    videoEl.setAttribute("aria-label", `Participant ${remotePeerId} video`);
-
-    const label = document.createElement("div");
-    label.className = "video-label";
-    label.id = `label-${remotePeerId}`;
-
-    const labelDot = document.createElement("i");
-    labelDot.className = "fa-solid fa-circle text-amber-500 fa-fade text-[10px]";
-    labelDot.setAttribute("aria-hidden", "true");
-    labelDot.id = `dot-${remotePeerId}`;
-
-    const labelText = document.createElement("span");
-    labelText.className = "font-mono font-bold";
-    labelText.title = remotePeerId;
-    labelText.textContent = remotePeerId;
-
-    label.appendChild(labelDot);
-    label.appendChild(labelText);
-
-    videoWrapper.appendChild(videoEl);
-    videoWrapper.appendChild(label);
-
-    const videoGrid = $("video-grid");
-    if (videoGrid) videoGrid.appendChild(videoWrapper);
-
-    call.on("stream", (remoteStream) => {
-      videoEl.srcObject = remoteStream;
-      const dot = $(`dot-${remotePeerId}`);
-      if (dot) dot.className = "fa-solid fa-circle text-green-500 text-[10px]";
->>>>>>> bf0030e (fix toggle)
       state.connected = true;
       const count = activeCalls.size;
       updateStatus(
-        `<i class="fa-solid fa-lock text-primary mr-1"></i> Encrypted call active (${count} participant${count !== 1 ? "s" : ""})`,
+        "fa-solid fa-lock text-primary",
+        `Encrypted call active (${count} participant${count !== 1 ? "s" : ""})`,
         "success"
       );
-<<<<<<< HEAD
-      setDotStatus("online");
-<<<<<<< HEAD
-=======
-=======
       setStatusIcon("online");
->>>>>>> bf0030e (fix toggle)
       if ($("call-controls")) {
         $("call-controls").classList.remove("hidden");
         $("btn-noise") && $("btn-noise").classList.remove("hidden");
         $("btn-screen") && $("btn-screen").classList.remove("hidden");
         $("btn-end") && $("btn-end").classList.remove("hidden");
       }
->>>>>>> 747222e (Delayed Media Permissions)
       updateParticipantsList();
       sendProfileTo(remotePeerId, true);
     });
@@ -1058,25 +903,18 @@ const VideoChat = (() => {
       if (wrapper) wrapper.remove();
       if (activeCalls.size === 0) {
         state.connected = false;
-<<<<<<< HEAD
-        updateStatus("Call ended", "muted");
-        setDotStatus("offline");
-<<<<<<< HEAD
-=======
-=======
-        updateStatus(`<i class="fa-solid fa-phone-slash mr-1"></i> Call ended`, "muted");
+        updateStatus("fa-solid fa-phone-slash", "Call ended", "muted");
         setStatusIcon("offline");
->>>>>>> bf0030e (fix toggle)
         if ($("call-controls")) {
           $("btn-noise") && $("btn-noise").classList.add("hidden");
           $("btn-screen") && $("btn-screen").classList.add("hidden");
           $("btn-end") && $("btn-end").classList.add("hidden");
         }
->>>>>>> 747222e (Delayed Media Permissions)
       } else {
         const count = activeCalls.size;
         updateStatus(
-          `🔒 Encrypted call active (${count} participant${count !== 1 ? "s" : ""})`,
+          "fa-solid fa-lock text-primary",
+          `Encrypted call active (${count} participant${count !== 1 ? "s" : ""})`,
           "success"
         );
       }
@@ -1164,11 +1002,21 @@ const VideoChat = (() => {
       return;
     }
 
-    const ls = await ensureLocalStream();
-    if (!ls) return;
+    if (!consentGiven) {
+      const ok = await askConsent("the remote participant");
+      if (!ok) return;
+    }
+
+    // Acquire media tracks BEFORE calling to ensure senders are created
     micMuted = false;
     camOff = false;
     updateMediaButtons();
+
+    const ok = await startLocalMedia();
+    if (!ok) return; // User denied or error
+
+    const ls = await ensureLocalStream();
+    if (!ls) return;
 
     // Ensure remotePeerId is a string before trimming
     if (typeof remotePeerId !== "string") {
@@ -1200,8 +1048,8 @@ const VideoChat = (() => {
       if (!ok) return;
     }
 
-    updateStatus("Calling…", "warning");
-    setDotStatus("connecting");
+    updateStatus("fa-solid fa-spinner fa-spin", "Calling...", "warning");
+    setStatusIcon("connecting");
     const call = peer.call(remotePeerId, voiceStream || localStream);
     activeCalls.set(remotePeerId, call);
     updateParticipantsList();
@@ -1360,7 +1208,7 @@ const VideoChat = (() => {
     localSpeakingUntil = 0;
     setTileSpeakingIndicator("local", false);
     state.connected = false;
-    updateStatus(`<i class="fa-solid fa-phone-slash mr-1"></i> Call ended`, "muted");
+    updateStatus("fa-solid fa-phone-slash", "Call ended", "muted");
     setStatusIcon("offline");
     const videoGrid = $("video-grid");
     if (videoGrid) {
@@ -1394,7 +1242,6 @@ const VideoChat = (() => {
       localStream.getTracks().forEach((t) => t.stop());
       localStream = null;
     }
-<<<<<<< HEAD
     voiceStream = null;
     if (voiceAnimFrame) {
       cancelAnimationFrame(voiceAnimFrame);
@@ -1412,12 +1259,14 @@ const VideoChat = (() => {
     localSpeakingUntil = 0;
     setTileSpeakingIndicator("local", false);
     if (typeof VoiceChanger !== "undefined") VoiceChanger.destroy();
+    
     /* Reset monitor button state */
     const monitorBtn = $("btn-monitor");
     if (monitorBtn) {
       monitorBtn.classList.remove("active");
       monitorBtn.setAttribute("aria-pressed", "false");
     }
+    
     /* Reset voice mode buttons to normal, clear all per-effect slider rows */
     document.querySelectorAll("[data-voice-mode]").forEach((btn) => {
       const isNormal = btn.dataset.voiceMode === "normal";
@@ -1427,14 +1276,8 @@ const VideoChat = (() => {
     const effectSlidersContainer = document.getElementById("effect-sliders-container");
     if (effectSlidersContainer) effectSlidersContainer.innerHTML = "";
     updateLocalTilePresentation();
-    setDotStatus("offline");
-    updateStatus("Disconnected", "muted");
-=======
-    if (voiceAnimFrame) cancelAnimationFrame(voiceAnimFrame);
-    if (audioContext) audioContext.close();
     setStatusIcon("offline");
-    updateStatus(`<i class="fa-solid fa-power-off mr-1"></i> Disconnected`, "muted");
->>>>>>> bf0030e (fix toggle)
+    updateStatus("fa-solid fa-power-off", "Disconnected", "muted");
     showToast("Session ended and media released", "success");
   }
 
@@ -1772,17 +1615,10 @@ const VideoChat = (() => {
       overlay.style.display = "flex";
       overlay.innerHTML = `
         <div class="modal" style="max-width:440px">
-<<<<<<< HEAD
-          <h3 style="display:flex;align-items:center;gap:0.5rem"><i class="fa-solid fa-shield-halved" aria-hidden="true"></i>Recording Consent Required</h3>
+          <h3 style="display:flex;align-items:center;gap:0.5rem"><i class="fa-solid fa-shield-halved text-primary" aria-hidden="true"></i>Recording Consent Required</h3>
           <p>This call may be recorded for AI notes and security purposes. Do you consent to participate in this secure call with <strong>${callerName}</strong>?</p>
           <div class="alert alert-info" style="margin-bottom:1rem">
-            <i class="fa-solid fa-circle-info" aria-hidden="true"></i>
-=======
-          <h3><i class="fa-solid fa-shield-halved text-primary mr-2"></i>Recording Consent Required</h3>
-          <p>This call may be recorded for AI notes and security purposes. Do you consent to participate in this secure call with <strong style="color:#fff">${callerName}</strong>?</p>
-          <div class="alert alert-info" style="margin-bottom:1rem">
-            <i class="fa-solid fa-circle-info text-primary mr-2"></i>
->>>>>>> bf0030e (fix toggle)
+            <i class="fa-solid fa-circle-info text-primary" aria-hidden="true"></i>
             <span>Consent is cryptographically timestamped and stored locally. You can withdraw at any time.</span>
           </div>
           <div style="display:flex;gap:0.75rem;justify-content:flex-end">

--- a/public/js/video.js
+++ b/public/js/video.js
@@ -45,13 +45,20 @@ const VideoChat = (() => {
   function updateStatus(text, type = "muted") {
     const el = $("connection-status");
     if (!el) return;
-    el.textContent = text;
+    el.innerHTML = text;
     el.className = `text-${type}`;
   }
 
-  function setDotStatus(status) {
-    const dot = $("status-dot");
-    if (dot) dot.className = `status-dot ${status}`;
+  function setStatusIcon(status) {
+    const icon = $("status-icon");
+    if (!icon) return;
+    if (status === "online") {
+      icon.className = "fa-solid fa-circle text-green-500";
+    } else if (status === "offline") {
+      icon.className = "fa-solid fa-circle text-gray-400";
+    } else if (status === "connecting") {
+      icon.className = "fa-solid fa-circle text-amber-500 fa-fade";
+    }
   }
 
   function normalizeDisplayName(value) {
@@ -473,17 +480,17 @@ const VideoChat = (() => {
   function getCameraInstructions(browser) {
     const steps = {
       chrome: `<strong>Google Chrome:</strong><ol style="margin:0.5rem 0 0 1.25rem;display:flex;flex-direction:column;gap:0.3rem">
-        <li>Click the <strong>camera blocked</strong> icon (🔒 or 📷) in the address bar.</li>
+        <li>Click the <strong>camera/lock</strong> icon in the address bar.</li>
         <li>Select <strong>Always allow</strong> for the camera and microphone, then click <strong>Done</strong>.</li>
         <li>Or go to <strong>Settings → Privacy and security → Site settings → Camera</strong> and allow this site.</li>
         <li>Reload the page and click <em>Try Again</em>.</li></ol>`,
       edge: `<strong>Microsoft Edge:</strong><ol style="margin:0.5rem 0 0 1.25rem;display:flex;flex-direction:column;gap:0.3rem">
-        <li>Click the <strong>camera blocked</strong> icon (🔒 or 📷) in the address bar.</li>
+        <li>Click the <strong>camera/lock</strong> icon in the address bar.</li>
         <li>Set Camera and Microphone permissions to <strong>Allow</strong>, then click <strong>Save</strong>.</li>
         <li>Or go to <strong>Settings → Cookies and site permissions → Camera</strong> and add this site to the allow list.</li>
         <li>Reload the page and click <em>Try Again</em>.</li></ol>`,
       firefox: `<strong>Mozilla Firefox:</strong><ol style="margin:0.5rem 0 0 1.25rem;display:flex;flex-direction:column;gap:0.3rem">
-        <li>Click the <strong>camera blocked</strong> icon (🎥 with a slash) in the address bar.</li>
+        <li>Click the <strong>permissions icon</strong> (camera icon with a slash) in the address bar.</li>
         <li>Click <strong>Blocked Temporarily</strong> or <strong>Blocked</strong> next to Camera and Microphone and choose <strong>Allow</strong>.</li>
         <li>Or go to <strong>about:preferences#privacy</strong> → Permissions → Camera → Settings, and allow this site.</li>
         <li>Reload the page and click <em>Try Again</em>.</li></ol>`,
@@ -492,7 +499,7 @@ const VideoChat = (() => {
         <li>Set Camera and Microphone to <strong>Allow</strong>.</li>
         <li>Reload the page and click <em>Try Again</em>.</li></ol>`,
       opera: `<strong>Opera:</strong><ol style="margin:0.5rem 0 0 1.25rem;display:flex;flex-direction:column;gap:0.3rem">
-        <li>Click the <strong>camera blocked</strong> icon (🔒 or 📷) in the address bar.</li>
+        <li>Click the <strong>camera/lock</strong> icon in the address bar.</li>
         <li>Select <strong>Always allow</strong> for the camera and microphone, then click <strong>Done</strong>.</li>
         <li>Or go to <strong>Settings → Privacy &amp; security → Site settings → Camera</strong> and allow this site.</li>
         <li>Reload the page and click <em>Try Again</em>.</li></ol>`,
@@ -610,17 +617,46 @@ const VideoChat = (() => {
 
   let mediaPromise = null;
 
-  async function startLocalMedia() {
+  async function ensureLocalStream() {
+    if (!localStream) {
+      localStream = new MediaStream();
+      attachStream(localStream);
+    }
+    return localStream;
+  }
+
+  async function startLocalMedia(constraints = { video: true, audio: true }) {
     if (mediaPromise) return mediaPromise;
     mediaPromise = (async () => {
-      // 1. Try full video + audio
       try {
+<<<<<<< HEAD
         localStream = await navigator.mediaDevices.getUserMedia({
           video: true,
           audio: true,
         });
         await attachStream(localStream);
         applyInitialMediaPreferences();
+=======
+        const stream = await navigator.mediaDevices.getUserMedia(constraints);
+        const ls = await ensureLocalStream();
+
+        if (constraints.audio) {
+          stream.getAudioTracks().forEach((t) => {
+            t.enabled = !micMuted;
+            ls.addTrack(t);
+            updateTracksInCalls(t, "audio");
+          });
+        }
+        if (constraints.video) {
+          stream.getVideoTracks().forEach((t) => {
+            t.enabled = !camOff;
+            ls.addTrack(t);
+            updateTracksInCalls(t, "video");
+            const localVideo = $("local-video");
+            if (localVideo) localVideo.srcObject = ls;
+          });
+        }
+>>>>>>> bf0030e (fix toggle)
         return true;
       } catch (err) {
         if (
@@ -631,21 +667,10 @@ const VideoChat = (() => {
           showCameraDenied();
           return false;
         }
-
-        if (err.name === "NotReadableError" || err.name === "TrackStartError") {
-          showToast(
-            "Camera or microphone is already in use by another application. Please close it and reload.",
-            "error"
-          );
-          return false;
-        }
-
-        // For NotFoundError / DevicesNotFoundError try partial fallbacks below.
-        if (err.name !== "NotFoundError" && err.name !== "DevicesNotFoundError") {
-          showToast("Could not access camera/microphone: " + err.message, "error");
-          return false;
-        }
+        showToast("Access error: " + err.message, "error");
+        return false;
       }
+<<<<<<< HEAD
 
       // 2. No combined device found — try audio-only
       try {
@@ -719,10 +744,12 @@ const VideoChat = (() => {
         "error"
       );
       return false;
+=======
+>>>>>>> bf0030e (fix toggle)
     })();
 
     const result = await mediaPromise;
-    if (!result) mediaPromise = null; // Allow retry if it failed
+    mediaPromise = null; 
     return result;
   }
 
@@ -800,11 +827,16 @@ const VideoChat = (() => {
 
     peer.on("open", (id) => {
       $("my-peer-id") && ($("my-peer-id").textContent = id);
+<<<<<<< HEAD
       updateStatus("Ready — share your Room ID", "secondary");
       setDotStatus("online");
       updateLocalTilePresentation();
+=======
+      updateStatus(`<i class="fa-solid fa-share-nodes mr-1"></i> Ready — share your Room ID`, "secondary");
+      setStatusIcon("online");
+>>>>>>> bf0030e (fix toggle)
       showToast("Connected to signaling server", "success");
-      // Auto-connect if a room ID was passed in the URL
+      // Populate room ID if passed in URL, but wait for user to click "Add Participant"
       const params = new URLSearchParams(window.location.search);
       const joinId = params.get("room");
       if (joinId && joinId !== state.peerId) {
@@ -812,7 +844,7 @@ const VideoChat = (() => {
         if (remoteInput) {
           remoteInput.value = joinId;
         }
-        callPeer(joinId);
+        showToast("Room ID loaded from link — click Add Participant to join", "info");
       }
     });
 
@@ -834,6 +866,7 @@ const VideoChat = (() => {
       incomingCall.answer(voiceStream || localStream);
 =======
 
+<<<<<<< HEAD
       if (!localStream) {
         micMuted = false;
         camOff = false;
@@ -846,6 +879,13 @@ const VideoChat = (() => {
 
       incomingCall.answer(localStream);
 >>>>>>> 747222e (Delayed Media Permissions)
+=======
+      const ls = await ensureLocalStream();
+      micMuted = false;
+      camOff = false;
+      updateMediaButtons();
+      incomingCall.answer(ls);
+>>>>>>> bf0030e (fix toggle)
       handleCallStream(incomingCall);
       ensureDataConn(incomingCall.peer);
       sendPeerListTo(incomingCall.peer);
@@ -856,14 +896,14 @@ const VideoChat = (() => {
     });
 
     peer.on("error", (err) => {
-      updateStatus("Error: " + err.message, "danger");
-      setDotStatus("offline");
+      updateStatus(`<i class="fa-solid fa-circle-exclamation mr-1"></i> Error: ` + err.message, "danger");
+      setStatusIcon("offline");
       showToast("Connection error: " + err.type, "error");
     });
 
     peer.on("disconnected", () => {
-      updateStatus("Disconnected", "warning");
-      setDotStatus("offline");
+      updateStatus(`<i class="fa-solid fa-plug-circle-xmark mr-1"></i> Disconnected`, "warning");
+      setStatusIcon("offline");
     });
   }
 
@@ -889,8 +929,8 @@ const VideoChat = (() => {
       const nameSpan = document.createElement("span");
       nameSpan.className = "flex min-w-0 items-center gap-2";
 
-      const dot = document.createElement("span");
-      dot.className = "status-dot online";
+      const dot = document.createElement("i");
+      dot.className = "fa-solid fa-circle text-green-500 text-[10px]";
       dot.setAttribute("aria-hidden", "true");
 
       const textWrap = document.createElement("span");
@@ -927,6 +967,7 @@ const VideoChat = (() => {
 
   function handleCallStream(call) {
     const remotePeerId = call.peer;
+<<<<<<< HEAD
     const tile = ensureRemoteTile(remotePeerId);
     const videoEl = tile ? tile.video : null;
     updateTilePresentation(remotePeerId);
@@ -937,15 +978,58 @@ const VideoChat = (() => {
       }
       attachRemoteSpeakingMonitor(remotePeerId, remoteStream);
       updateTilePresentation(remotePeerId);
+=======
+
+    const videoWrapper = document.createElement("div");
+    videoWrapper.className = "video-wrapper bg-gray-900";
+    videoWrapper.id = `wrapper-${remotePeerId}`;
+
+    const videoEl = document.createElement("video");
+    videoEl.autoplay = true;
+    videoEl.playsInline = true;
+    videoEl.setAttribute("aria-label", `Participant ${remotePeerId} video`);
+
+    const label = document.createElement("div");
+    label.className = "video-label";
+    label.id = `label-${remotePeerId}`;
+
+    const labelDot = document.createElement("i");
+    labelDot.className = "fa-solid fa-circle text-amber-500 fa-fade text-[10px]";
+    labelDot.setAttribute("aria-hidden", "true");
+    labelDot.id = `dot-${remotePeerId}`;
+
+    const labelText = document.createElement("span");
+    labelText.className = "font-mono font-bold";
+    labelText.title = remotePeerId;
+    labelText.textContent = remotePeerId;
+
+    label.appendChild(labelDot);
+    label.appendChild(labelText);
+
+    videoWrapper.appendChild(videoEl);
+    videoWrapper.appendChild(label);
+
+    const videoGrid = $("video-grid");
+    if (videoGrid) videoGrid.appendChild(videoWrapper);
+
+    call.on("stream", (remoteStream) => {
+      videoEl.srcObject = remoteStream;
+      const dot = $(`dot-${remotePeerId}`);
+      if (dot) dot.className = "fa-solid fa-circle text-green-500 text-[10px]";
+>>>>>>> bf0030e (fix toggle)
       state.connected = true;
       const count = activeCalls.size;
       updateStatus(
-        `🔒 Encrypted call active (${count} participant${count !== 1 ? "s" : ""})`,
+        `<i class="fa-solid fa-lock text-primary mr-1"></i> Encrypted call active (${count} participant${count !== 1 ? "s" : ""})`,
         "success"
       );
+<<<<<<< HEAD
       setDotStatus("online");
 <<<<<<< HEAD
 =======
+=======
+      setStatusIcon("online");
+>>>>>>> bf0030e (fix toggle)
       if ($("call-controls")) {
         $("call-controls").classList.remove("hidden");
         $("btn-noise") && $("btn-noise").classList.remove("hidden");
@@ -974,10 +1058,15 @@ const VideoChat = (() => {
       if (wrapper) wrapper.remove();
       if (activeCalls.size === 0) {
         state.connected = false;
+<<<<<<< HEAD
         updateStatus("Call ended", "muted");
         setDotStatus("offline");
 <<<<<<< HEAD
 =======
+=======
+        updateStatus(`<i class="fa-solid fa-phone-slash mr-1"></i> Call ended`, "muted");
+        setStatusIcon("offline");
+>>>>>>> bf0030e (fix toggle)
         if ($("call-controls")) {
           $("btn-noise") && $("btn-noise").classList.add("hidden");
           $("btn-screen") && $("btn-screen").classList.add("hidden");
@@ -1070,19 +1159,18 @@ const VideoChat = (() => {
       showToast("Not connected to server", "error");
       return;
     }
-    if (!localStream) {
-      // If joining a call directly, enable both by default
-      micMuted = false;
-      camOff = false;
-      const ok = await startLocalMedia();
-      if (!ok) return;
-    }
     if (!remotePeerId) {
       showToast("Enter a Room ID to call", "warning");
       return;
     }
 
-    // Ensure remotePeerId is a string before trimming (defensive against network data)
+    const ls = await ensureLocalStream();
+    if (!ls) return;
+    micMuted = false;
+    camOff = false;
+    updateMediaButtons();
+
+    // Ensure remotePeerId is a string before trimming
     if (typeof remotePeerId !== "string") {
       showToast("Invalid Room ID format", "error");
       return;
@@ -1090,11 +1178,6 @@ const VideoChat = (() => {
 
     // Normalize the peer ID by trimming whitespace
     remotePeerId = remotePeerId.trim();
-
-    if (!remotePeerId) {
-      showToast("Enter a Room ID to call", "warning");
-      return;
-    }
 
     if (!isValidRoomId(remotePeerId)) {
       showToast(
@@ -1127,16 +1210,94 @@ const VideoChat = (() => {
   }
 
   /* ── Controls ── */
+  async function updateTracksInCalls(newTrack, kind) {
+    for (const call of activeCalls.values()) {
+      const pc = call.peerConnection;
+      if (!pc) continue;
+      const senders = pc.getSenders();
+      const sender = senders.find((s) => s.track && s.track.kind === kind);
+      if (sender) {
+        try {
+          await sender.replaceTrack(newTrack);
+        } catch (err) {
+          console.error(`Failed to replace ${kind} track:`, err);
+        }
+      }
+    }
+  }
+
+  function updateMediaButtons() {
+    const micBtn = $("btn-mic");
+    if (micBtn) {
+      micBtn.innerHTML = micMuted
+        ? '<i class="fa-solid fa-microphone-slash" aria-hidden="true"></i>'
+        : '<i class="fa-solid fa-microphone" aria-hidden="true"></i>';
+      micBtn.title = micMuted ? "Unmute mic" : "Mute mic";
+      micBtn.classList.toggle("active", micMuted);
+    }
+    const camBtn = $("btn-cam");
+    if (camBtn) {
+      camBtn.innerHTML = camOff
+        ? '<i class="fa-solid fa-video-slash" aria-hidden="true"></i>'
+        : '<i class="fa-solid fa-video" aria-hidden="true"></i>';
+      camBtn.title = camOff ? "Enable camera" : "Disable camera";
+      camBtn.classList.toggle("active", camOff);
+    }
+  }
+
+  /* ── Initial Permission Helper ── */
+  async function checkInitialPermissions() {
+    if (!navigator.permissions || !navigator.permissions.query) return;
+    try {
+      // Check camera & mic state without requesting them
+      const camStatus = await navigator.permissions.query({ name: "camera" });
+      const micStatus = await navigator.permissions.query({ name: "microphone" });
+
+      const updateHint = () => {
+        const isBlocked = camStatus.state === "denied" || micStatus.state === "denied";
+        const hint = $("permission-hint");
+        if (hint) {
+          if (isBlocked) hint.classList.remove("hidden");
+          else hint.classList.add("hidden");
+        }
+      };
+
+      updateHint();
+      camStatus.onchange = updateHint;
+      micStatus.onchange = updateHint;
+    } catch (e) {
+      console.warn("Permissions API not supported for media:", e);
+    }
+  }
+
   async function toggleMic() {
     micMuted = !micMuted;
-    if (!localStream) {
-      const ok = await startLocalMedia();
-      if (!ok) {
-        micMuted = true; // reset state
-        return;
+    updateMediaButtons(); // Update instantly for zero delay UI
+    if (!localStream || localStream.getAudioTracks().length === 0) {
+      if (!micMuted) {
+        const ok = await startLocalMedia({ audio: true, video: false });
+        if (!ok) {
+          micMuted = true;
+          updateMediaButtons();
+          return;
+        }
       }
     } else {
-      localStream.getAudioTracks().forEach((t) => (t.enabled = !micMuted));
+      if (micMuted) {
+        // Turning OFF: Stop hardware
+        localStream.getAudioTracks().forEach((t) => {
+          t.stop();
+          localStream.removeTrack(t);
+        });
+        await updateTracksInCalls(null, "audio");
+      } else {
+        // Turning ON
+        const ok = await startLocalMedia({ audio: true, video: false });
+        if (!ok) {
+          micMuted = true;
+          updateMediaButtons();
+        }
+      }
     }
 
     syncControlButtons();
@@ -1147,14 +1308,32 @@ const VideoChat = (() => {
 
   async function toggleCamera() {
     camOff = !camOff;
-    if (!localStream) {
-      const ok = await startLocalMedia();
-      if (!ok) {
-        camOff = true; // reset state
-        return;
+    updateMediaButtons(); // Update instantly
+    if (!localStream || localStream.getVideoTracks().length === 0) {
+      if (!camOff) {
+        const ok = await startLocalMedia({ video: true, audio: false });
+        if (!ok) {
+          camOff = true;
+          updateMediaButtons();
+          return;
+        }
       }
     } else {
-      localStream.getVideoTracks().forEach((t) => (t.enabled = !camOff));
+      if (camOff) {
+        // Turning OFF: Stop hardware
+        localStream.getVideoTracks().forEach((t) => {
+          t.stop();
+          localStream.removeTrack(t);
+        });
+        await updateTracksInCalls(null, "video");
+      } else {
+        // Turning ON
+        const ok = await startLocalMedia({ video: true, audio: false });
+        if (!ok) {
+          camOff = true;
+          updateMediaButtons();
+        }
+      }
     }
 
     syncControlButtons();
@@ -1181,8 +1360,8 @@ const VideoChat = (() => {
     localSpeakingUntil = 0;
     setTileSpeakingIndicator("local", false);
     state.connected = false;
-    updateStatus("Call ended", "muted");
-    setDotStatus("offline");
+    updateStatus(`<i class="fa-solid fa-phone-slash mr-1"></i> Call ended`, "muted");
+    setStatusIcon("offline");
     const videoGrid = $("video-grid");
     if (videoGrid) {
       videoGrid.querySelectorAll(".video-wrapper:not(:first-child)").forEach((w) => w.remove());
@@ -1215,6 +1394,7 @@ const VideoChat = (() => {
       localStream.getTracks().forEach((t) => t.stop());
       localStream = null;
     }
+<<<<<<< HEAD
     voiceStream = null;
     if (voiceAnimFrame) {
       cancelAnimationFrame(voiceAnimFrame);
@@ -1249,6 +1429,12 @@ const VideoChat = (() => {
     updateLocalTilePresentation();
     setDotStatus("offline");
     updateStatus("Disconnected", "muted");
+=======
+    if (voiceAnimFrame) cancelAnimationFrame(voiceAnimFrame);
+    if (audioContext) audioContext.close();
+    setStatusIcon("offline");
+    updateStatus(`<i class="fa-solid fa-power-off mr-1"></i> Disconnected`, "muted");
+>>>>>>> bf0030e (fix toggle)
     showToast("Session ended and media released", "success");
   }
 
@@ -1586,10 +1772,17 @@ const VideoChat = (() => {
       overlay.style.display = "flex";
       overlay.innerHTML = `
         <div class="modal" style="max-width:440px">
+<<<<<<< HEAD
           <h3 style="display:flex;align-items:center;gap:0.5rem"><i class="fa-solid fa-shield-halved" aria-hidden="true"></i>Recording Consent Required</h3>
           <p>This call may be recorded for AI notes and security purposes. Do you consent to participate in this secure call with <strong>${callerName}</strong>?</p>
           <div class="alert alert-info" style="margin-bottom:1rem">
             <i class="fa-solid fa-circle-info" aria-hidden="true"></i>
+=======
+          <h3><i class="fa-solid fa-shield-halved text-primary mr-2"></i>Recording Consent Required</h3>
+          <p>This call may be recorded for AI notes and security purposes. Do you consent to participate in this secure call with <strong style="color:#fff">${callerName}</strong>?</p>
+          <div class="alert alert-info" style="margin-bottom:1rem">
+            <i class="fa-solid fa-circle-info text-primary mr-2"></i>
+>>>>>>> bf0030e (fix toggle)
             <span>Consent is cryptographically timestamped and stored locally. You can withdraw at any time.</span>
           </div>
           <div style="display:flex;gap:0.75rem;justify-content:flex-end">
@@ -1725,6 +1918,10 @@ const VideoChat = (() => {
     
     // Always init peer regardless of success of startLocalMedia (can join without media)
     await initPeer();
+    checkInitialPermissions();
+    window.addEventListener("beforeunload", () => {
+      hangup();
+    });
     return true;
 
   return {

--- a/public/js/video.js
+++ b/public/js/video.js
@@ -1768,7 +1768,7 @@ const VideoChat = (() => {
     }
   }
 
-  /* ── Init ── */
+  async function init() {
     state.displayName = resolveDisplayName();
     state.displayInitials = makeInitials(state.displayName);
 
@@ -1789,6 +1789,7 @@ const VideoChat = (() => {
       hangup();
     });
     return true;
+  }
 
   return {
     init,

--- a/public/js/video.js
+++ b/public/js/video.js
@@ -1701,12 +1701,12 @@ const VideoChat = (() => {
       const screenStream = await navigator.mediaDevices.getDisplayMedia({ video: true });
       const screenTrack = screenStream.getVideoTracks()[0];
       for (const call of activeCalls.values()) {
-        if (call.peerConnection) {
-          const sender = call.peerConnection
-            .getSenders()
-            .find((s) => s.track && s.track.kind === "video");
-          if (sender) await sender.replaceTrack(screenTrack);
+        // Use cached sender reference (robust against null tracks)
+        let sender = call.sendersByKind ? call.sendersByKind.video : null;
+        if (!sender && call.peerConnection) {
+          sender = call.peerConnection.getSenders().find((s) => s.track && s.track.kind === "video");
         }
+        if (sender) await sender.replaceTrack(screenTrack);
       }
       const localVideo = $("local-video");
       if (localVideo) localVideo.srcObject = screenStream;

--- a/public/js/video.js
+++ b/public/js/video.js
@@ -637,9 +637,32 @@ const VideoChat = (() => {
     if (mediaPromise) return mediaPromise;
     mediaPromise = (async () => {
       try {
-        localStream = await navigator.mediaDevices.getUserMedia(constraints);
-        await attachStream(localStream);
-        applyInitialMediaPreferences();
+        const ls = await ensureLocalStream();
+        const request = {
+          audio: !!constraints.audio && ls.getAudioTracks().length === 0,
+          video: !!constraints.video && ls.getVideoTracks().length === 0,
+        };
+        if (!request.audio && !request.video) return true;
+
+        const stream = await navigator.mediaDevices.getUserMedia(request);
+
+        if (constraints.audio) {
+          stream.getAudioTracks().forEach((t) => {
+            t.enabled = !micMuted;
+            ls.addTrack(t);
+            updateTracksInCalls(t, "audio");
+          });
+          startVoiceMeter(ls);
+        }
+        if (constraints.video) {
+          stream.getVideoTracks().forEach((t) => {
+            t.enabled = !camOff;
+            ls.addTrack(t);
+            updateTracksInCalls(t, "video");
+            const localVideo = $("local-video");
+            if (localVideo) localVideo.srcObject = ls;
+          });
+        }
         return true;
       } catch (err) {
         if (
@@ -763,18 +786,15 @@ const VideoChat = (() => {
           return;
         }
       }
-      activeCalls.set(incomingCall.peer, incomingCall);
-      updateParticipantsList();
-      
-      micMuted = false;
-      camOff = false;
-      updateMediaButtons();
-      
-      const ok = await startLocalMedia();
-      if (!ok) {
+
+      const mediaOk = await startLocalMedia();
+      if (!mediaOk) {
         incomingCall.close();
         return;
       }
+
+      activeCalls.set(incomingCall.peer, incomingCall);
+      updateParticipantsList();
       
       incomingCall.answer(voiceStream || localStream);
       handleCallStream(incomingCall);
@@ -858,6 +878,15 @@ const VideoChat = (() => {
 
   function handleCallStream(call) {
     const remotePeerId = call.peer;
+    // Persist sender references here to ensure replaceTrack works even if s.track is switched to null later
+    call.sendersByKind = {};
+    const pc = call.peerConnection;
+    if (pc) {
+      pc.getSenders().forEach((s) => {
+        if (s.track) call.sendersByKind[s.track.kind] = s;
+      });
+    }
+
     const tile = ensureRemoteTile(remotePeerId);
     const videoEl = tile ? tile.video : null;
     updateTilePresentation(remotePeerId);
@@ -1002,22 +1031,6 @@ const VideoChat = (() => {
       return;
     }
 
-    if (!consentGiven) {
-      const ok = await askConsent("the remote participant");
-      if (!ok) return;
-    }
-
-    // Acquire media tracks BEFORE calling to ensure senders are created
-    micMuted = false;
-    camOff = false;
-    updateMediaButtons();
-
-    const ok = await startLocalMedia();
-    if (!ok) return; // User denied or error
-
-    const ls = await ensureLocalStream();
-    if (!ls) return;
-
     // Ensure remotePeerId is a string before trimming
     if (typeof remotePeerId !== "string") {
       showToast("Invalid Room ID format", "error");
@@ -1048,6 +1061,13 @@ const VideoChat = (() => {
       if (!ok) return;
     }
 
+    micMuted = false;
+    camOff = false;
+    updateMediaButtons();
+
+    const ok = await startLocalMedia();
+    if (!ok) return;
+
     updateStatus("fa-solid fa-spinner fa-spin", "Calling...", "warning");
     setStatusIcon("connecting");
     const call = peer.call(remotePeerId, voiceStream || localStream);
@@ -1060,10 +1080,18 @@ const VideoChat = (() => {
   /* ── Controls ── */
   async function updateTracksInCalls(newTrack, kind) {
     for (const call of activeCalls.values()) {
-      const pc = call.peerConnection;
-      if (!pc) continue;
-      const senders = pc.getSenders();
-      const sender = senders.find((s) => s.track && s.track.kind === kind);
+      // 1. Check saved senders first (robust against null tracks)
+      let sender = call.sendersByKind ? call.sendersByKind[kind] : null;
+      
+      // 2. Fallback to lookup if not saved yet
+      if (!sender) {
+        const pc = call.peerConnection;
+        if (!pc) continue;
+        sender = pc.getSenders().find((s) => s.track && s.track.kind === kind);
+        // Cache it for next time
+        if (sender && call.sendersByKind) call.sendersByKind[kind] = sender;
+      }
+
       if (sender) {
         try {
           await sender.replaceTrack(newTrack);
@@ -1616,7 +1644,7 @@ const VideoChat = (() => {
       overlay.innerHTML = `
         <div class="modal" style="max-width:440px">
           <h3 style="display:flex;align-items:center;gap:0.5rem"><i class="fa-solid fa-shield-halved text-primary" aria-hidden="true"></i>Recording Consent Required</h3>
-          <p>This call may be recorded for AI notes and security purposes. Do you consent to participate in this secure call with <strong>${callerName}</strong>?</p>
+          <p>This call may be recorded for AI notes and security purposes. Do you consent to participate in this secure call with <strong id="consent-caller-name" style="color:#fff"></strong>?</p>
           <div class="alert alert-info" style="margin-bottom:1rem">
             <i class="fa-solid fa-circle-info text-primary" aria-hidden="true"></i>
             <span>Consent is cryptographically timestamped and stored locally. You can withdraw at any time.</span>
@@ -1627,6 +1655,8 @@ const VideoChat = (() => {
           </div>
         </div>
       `;
+      const callerNameEl = overlay.querySelector("#consent-caller-name");
+      if (callerNameEl) callerNameEl.textContent = callerName;
       document.body.appendChild(overlay);
 
       overlay.querySelector("#consent-allow").onclick = () => {

--- a/src/pages/video-chat.html
+++ b/src/pages/video-chat.html
@@ -28,37 +28,27 @@
             },
           },
         },
-      };
-    </script>
+      },
+    };
+  </script>
 
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&display=swap"
-      rel="stylesheet"
-    />
-    <link
-      rel="stylesheet"
-      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"
-      referrerpolicy="no-referrer"
-    />
-    <link rel="stylesheet" href="css/main.css" />
-  </head>
-  <body class="font-sans antialiased">
-    <div class="pointer-events-none fixed inset-x-0 top-0 -z-10 h-full hero-glow"></div>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&display=swap"
+    rel="stylesheet" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"
+    referrerpolicy="no-referrer" />
+  <link rel="stylesheet" href="css/main.css" />
+</head>
 
-    <nav
-      class="sticky top-0 z-50 border-b border-neutral-border bg-white/95 backdrop-blur"
-      role="navigation"
-      aria-label="Main navigation"
-    >
-      <div class="mx-auto flex h-16 max-w-6xl items-center justify-between px-4 sm:px-6 lg:px-8">
-        <a class="flex items-center gap-3" href="/" aria-label="BLT-SafeCloak Home">
-          <img
-            src="img/logo.png"
-            alt="BLT-SafeCloak logo"
-            class="h-10 w-10 rounded-md object-contain"
-            onerror="
+<body class="font-sans antialiased">
+  <div class="pointer-events-none fixed inset-x-0 top-0 -z-10 h-full hero-glow"></div>
+
+  <nav class="sticky top-0 z-50 border-b border-neutral-border bg-white/95 backdrop-blur" role="navigation"
+    aria-label="Main navigation">
+    <div class="mx-auto flex h-16 max-w-6xl items-center justify-between px-4 sm:px-6 lg:px-8">
+      <a class="flex items-center gap-3" href="/" aria-label="BLT-SafeCloak Home">
+        <img src="img/logo.png" alt="BLT-SafeCloak logo" class="h-10 w-10 rounded-md object-contain" onerror="
               this.style.display = 'none';
               this.nextElementSibling.style.display = 'flex';
             "
@@ -483,20 +473,134 @@
       </main>
     </div>
 
-    <footer class="border-t border-neutral-border bg-white py-7" role="contentinfo">
-      <div class="mx-auto max-w-6xl px-4 text-center text-sm text-gray-600 sm:px-6 lg:px-8">
-        BLT-SafeCloak -
-        <a
-          href="https://github.com/OWASP-BLT/BLT-SafeCloak"
-          target="_blank"
-          rel="noopener"
-          class="text-red-600 hover:underline"
-          >OWASP BLT Project</a
-        >
-      </div>
-    </footer>
+        <aside aria-label="Room setup and connection info" class="space-y-4">
+          <!-- Privacy & Permissions Hint (Visible when blocked) -->
+          <div id="permission-hint" class="surface-card p-4 rounded-xl mb-4 hidden border-amber-200 bg-amber-50">
+            <div class="flex gap-3">
+              <i class="fa-solid fa-triangle-exclamation text-amber-500 mt-1"></i>
+              <div>
+                <h4 class="text-sm font-bold text-amber-900 mb-1">Permissions Blocked</h4>
+                <p class="text-xs text-amber-800 leading-relaxed">
+                  Your browser is preventing <b>Microphone/Camera</b> access. Click the <b>Lock Icon</b> next to the
+                  URL, toggle <b>On</b>, and refresh the page.
+                </p>
+              </div>
+            </div>
+          </div>
+          <div class="card">
+            <div class="card-header">
+              <h2 class="card-title">
+                <i class="fa-solid fa-key text-primary" aria-hidden="true"></i>
+                Your Room ID
+              </h2>
+            </div>
+            <div class="card-body">
+              <div
+                class="rounded-md border border-neutral-border bg-gray-50 px-3 py-3 text-center font-mono text-lg font-bold tracking-widest text-gray-900"
+                id="my-peer-id" aria-label="Your room ID">
+                Connecting...
+              </div>
+              <button class="btn btn-secondary mt-3 w-full" onclick="
+                    copyToClipboard(document.getElementById('my-peer-id').textContent, 'Room ID')
+                  " aria-label="Copy room ID to clipboard">
+                <i class="fa-regular fa-copy" aria-hidden="true"></i>
+                Copy Room ID
+              </button>
+              <button class="btn btn-primary mt-2 w-full" id="btn-copy-link" onclick="VideoChat.copyRoomLink()"
+                aria-label="Copy shareable room link to clipboard">
+                <i class="fa-solid fa-link" aria-hidden="true"></i>
+                Copy Room Link
+              </button>
+            </div>
+          </div>
 
-    <div id="toast-container" role="status" aria-live="polite"></div>
+          <div class="card">
+            <div class="card-header">
+              <h2 class="card-title">
+                <i class="fa-solid fa-phone text-primary" aria-hidden="true"></i>
+                Join a Room
+              </h2>
+            </div>
+            <div class="card-body">
+              <label class="block text-sm font-semibold text-gray-700 mb-2" for="remote-id">Remote Room ID</label>
+              <input type="text"
+                class="w-full border border-neutral-border rounded-md px-4 py-2 text-gray-900 placeholder-gray-500 focus:border-primary focus:ring-1 focus:ring-primary focus:outline-none transition-colors"
+                id="remote-id" placeholder="Enter Room ID..." autocomplete="off" aria-label="Remote room ID"
+                pattern="[ABCDEFGHJKLMNPQRSTUVWXYZ23456789]{6}" maxlength="6" inputmode="text" required />
+              <button class="btn btn-primary mt-3 w-full" id="btn-call" aria-label="Add participant to room">
+                <i class="fa-solid fa-user-plus" aria-hidden="true"></i>
+                Add Participant
+              </button>
+            </div>
+          </div>
+
+          <div class="card">
+            <div class="card-header">
+              <h2 class="card-title">
+                <i class="fa-solid fa-users text-primary" aria-hidden="true"></i>
+                Participants
+                <span id="participant-count" class="ml-auto text-xs font-bold text-gray-500" aria-live="polite">0
+                  connected</span>
+              </h2>
+            </div>
+            <div class="card-body" id="participants-list">
+              <p class="text-sm text-gray-500 text-center py-2">No participants connected</p>
+            </div>
+          </div>
+
+          <div class="card">
+            <div class="card-header">
+              <h2 class="card-title">
+                <i class="fa-solid fa-shield-halved text-primary" aria-hidden="true"></i>
+                Security
+              </h2>
+            </div>
+            <div class="card-body text-sm text-gray-600">
+              <ul class="space-y-1" role="list">
+                <li>
+                  <i class="fa-solid fa-check mr-2 text-primary" aria-hidden="true"></i>DTLS/SRTP
+                  transport
+                </li>
+                <li>
+                  <i class="fa-solid fa-check mr-2 text-primary" aria-hidden="true"></i>Peer-to-peer (no relay)
+                </li>
+                <li>
+                  <i class="fa-solid fa-check mr-2 text-primary" aria-hidden="true"></i>Consent
+                  timestamped
+                </li>
+                <li>
+                  <i class="fa-solid fa-check mr-2 text-primary" aria-hidden="true"></i>No server
+                  recording
+                </li>
+                <li>
+                  <i class="fa-solid fa-check mr-2 text-primary" aria-hidden="true"></i>Open-source
+                </li>
+              </ul>
+            </div>
+          </div>
+
+          <div class="grid gap-2">
+            <a href="/notes" class="btn btn-secondary" aria-label="Open secure notes">
+              <i class="fa-solid fa-note-sticky" aria-hidden="true"></i>
+              Open Secure Notes
+            </a>
+            <a href="/consent" class="btn btn-secondary" aria-label="View consent log">
+              <i class="fa-solid fa-scale-balanced" aria-hidden="true"></i>
+              View Consent Log
+            </a>
+          </div>
+        </aside>
+      </div>
+    </main>
+  </div>
+
+  <footer class="border-t border-neutral-border bg-white py-7" role="contentinfo">
+    <div class="mx-auto max-w-6xl px-4 text-center text-sm text-gray-600 sm:px-6 lg:px-8">
+      BLT-SafeCloak -
+      <a href="https://github.com/OWASP-BLT/BLT-SafeCloak" target="_blank" rel="noopener"
+        class="text-red-600 hover:underline">OWASP BLT Project</a>
+    </div>
+  </footer>
 
     <script src="js/ui.js"></script>
     <script src="js/voice-changer.js"></script>

--- a/src/pages/video-chat.html
+++ b/src/pages/video-chat.html
@@ -28,8 +28,7 @@
             },
           },
         },
-      },
-    };
+      };
   </script>
 
   <link rel="preconnect" href="https://fonts.googleapis.com" />


### PR DESCRIPTION
### Summary

- Controls visible on load with correct default (muted/off icons)
- Added status icons (connecting/online/offline) and improved status messages
- Permission hint + camera denied instructions enhanced
- Contextual controls (screen share, noise suppression, end call) shown only during active calls
- No permission prompt on page load
- Permissions requested only when user interacts (toggle/call)
- Supports audio-only / video-only fallbacks
- Better UX, clearer status, and safer media lifecycle

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New room-setup sidebar with peer ID, copy link, call button, participants list and security checklist.
  * Permission hint and camera/microphone denied panels with retry guidance; permission state checked at startup.
  * Call controls expanded (noise, screen, end); mic/cam buttons render and reflect state and caller consent name shown.

* **Bug Fixes**
  * Microphone and camera default to muted/off.
  * Media acquisition is lazy, de-duplicated and safer for concurrent requests.
  * Status now uses icon-based visuals and updates reliably during calls; track updates propagate to active calls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->