### PR TITLE
add backend API endpoints with health, features, notes, and consent

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,1 @@
+"""BLT-SafeCloak application package."""

--- a/src/libs/__init__.py
+++ b/src/libs/__init__.py
@@ -1,0 +1,1 @@
+"""Shared library helpers for the BLT-SafeCloak worker."""

--- a/src/libs/utils.py
+++ b/src/libs/utils.py
@@ -169,12 +169,13 @@ def method_not_allowed_response(allowed_methods: Iterable[str], message: Optiona
     Returns:
         Response object with JSON error payload
     """
-    methods = ', '.join(allowed_methods)
+    methods_list = list(allowed_methods)
+    methods = ', '.join(methods_list)
     return json_error_response(
         message or 'Method not allowed',
         status=405,
         code='method_not_allowed',
-        extra={'allowed_methods': list(allowed_methods)},
+        extra={'allowed_methods': methods_list},
         headers={
             'Allow': methods,
             'Access-Control-Allow-Methods': methods,

--- a/src/libs/utils.py
+++ b/src/libs/utils.py
@@ -12,10 +12,10 @@ Key design decisions:
 
 from workers import Response
 import json
-from typing import Any, Dict
+from typing import Any, Dict, Iterable, Optional
 
 
-def base_headers(content_type: str) -> Dict[str, str]:
+def base_headers(content_type: str, extra_headers: Optional[Dict[str, str]] = None) -> Dict[str, str]:
     """
     Create a base set of headers for all responses.
 
@@ -31,12 +31,16 @@ def base_headers(content_type: str) -> Dict[str, str]:
     Returns:
         Dictionary of headers
     """
-    return {
+    headers = {
         'Content-Type': content_type,
 
-        # Allows any origin to access the response
+        # TODO: Replace wildcard CORS with an explicit allowed-origin config before
+        # exposing any state-changing API routes.
         'Access-Control-Allow-Origin': '*',
     }
+    if extra_headers:
+        headers.update(extra_headers)
+    return headers
 
 
 def html_response(html_str: str, status: int = 200) -> Response:
@@ -83,7 +87,42 @@ def json_response(data: Any, status: int = 200) -> Response:
     )
 
 
-def cors_response(status: int = 204) -> Response:
+def json_error_response(message: str,
+                        status: int = 400,
+                        code: Optional[str] = None,
+                        extra: Optional[Dict[str, Any]] = None,
+                        headers: Optional[Dict[str, str]] = None) -> Response:
+    """
+    Create a JSON error response with a consistent schema.
+
+    Args:
+        message: Human-readable error message
+        status: HTTP status code
+        code: Optional machine-readable error code
+        extra: Optional additional JSON fields
+        headers: Optional extra response headers
+
+    Returns:
+        Response object with JSON error payload
+    """
+    payload = {
+        'error': message,
+        'status': status,
+    }
+    if code:
+        payload['code'] = code
+    if extra:
+        payload.update(extra)
+    return Response(
+        json.dumps(payload, ensure_ascii=False, default=str),
+        status=status,
+        headers=base_headers('application/json; charset=utf-8', headers)
+    )
+
+
+def cors_response(status: int = 204,
+                  allow_methods: str = 'GET, POST, OPTIONS',
+                  allow_headers: str = 'Content-Type') -> Response:
     """
     Create a CORS preflight (OPTIONS) response.
 
@@ -102,17 +141,41 @@ def cors_response(status: int = 204) -> Response:
         None,  # 204 responses should not include a body
         status=status,
         headers={
-            # Allow all origins 
+            # TODO: Replace wildcard CORS with an explicit allowed-origin config before
+            # exposing any state-changing API routes.
             'Access-Control-Allow-Origin': '*',
 
             # Allowed HTTP methods
-            'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+            'Access-Control-Allow-Methods': allow_methods,
 
             # Allowed request headers
-            'Access-Control-Allow-Headers': 'Content-Type',
+            'Access-Control-Allow-Headers': allow_headers,
 
             # Cache preflight response (in seconds basically 1 day)
             # Reduces repeated OPTIONS requests
             'Access-Control-Max-Age': '86400',
         }
     )
+
+
+def method_not_allowed_response(allowed_methods: Iterable[str], message: Optional[str] = None) -> Response:
+    """
+    Create a 405 Method Not Allowed response with both Allow and CORS method headers.
+
+    Args:
+        allowed_methods: Iterable of supported HTTP methods
+        message: Optional override for the error message
+
+    Returns:
+        Response object with JSON error payload
+    """
+    methods = ', '.join(allowed_methods)
+    return json_error_response(
+        message or 'Method not allowed',
+        status=405,
+        code='method_not_allowed',
+        extra={'allowed_methods': list(allowed_methods)},
+        headers={
+            'Allow': methods,
+            'Access-Control-Allow-Methods': methods,
+        })

--- a/src/main.py
+++ b/src/main.py
@@ -49,7 +49,7 @@ def _api_features_payload():
         'resources': {
             'notes': {
                 'endpoint': API_NOTES_PATH,
-                'storage': 'client-local',
+                'storage': 'browser-local-storage',
                 'encryption': 'client-side',
                 'placeholder': True,
                 'allowed_methods': list(API_READ_ONLY_METHODS),
@@ -57,7 +57,7 @@ def _api_features_payload():
             },
             'consent': {
                 'endpoint': API_CONSENT_PATH,
-                'storage': 'client-local',
+                'storage': 'browser-local-storage',
                 'integrity': 'client-side-sha256',
                 'placeholder': True,
                 'allowed_methods': list(API_READ_ONLY_METHODS),

--- a/src/main.py
+++ b/src/main.py
@@ -1,9 +1,17 @@
 # pylint: disable=too-few-public-methods
-from workers import WorkerEntrypoint, Response
-from urllib.parse import urlparse
+from datetime import datetime, timezone
 from pathlib import Path
+from urllib.parse import urlparse
 
-from libs.utils import html_response, cors_response
+from workers import WorkerEntrypoint, Response
+
+from libs.utils import (
+    cors_response,
+    html_response,
+    json_error_response,
+    json_response,
+    method_not_allowed_response,
+)
 
 # Route to HTML page mapping
 PAGES_MAP = {
@@ -12,6 +20,114 @@ PAGES_MAP = {
     '/notes': 'notes.html',
     '/consent': 'consent.html',
 }
+
+API_READ_ONLY_METHODS = ('GET', 'OPTIONS')
+API_NOTES_PATH = '/api/notes'
+API_CONSENT_PATH = '/api/consent'
+
+
+def _utc_timestamp():
+    """Return a UTC ISO-8601 timestamp for deployment verification."""
+    return datetime.now(timezone.utc).isoformat(timespec='seconds').replace('+00:00', 'Z')
+
+
+def _api_health_payload():
+    """Return basic service metadata for uptime and readiness checks."""
+    return {
+        'status': 'ok',
+        'service': 'blt-safecloak',
+        'runtime': 'cloudflare-python-worker',
+        'version': '0.1.0',
+        'timestamp': _utc_timestamp(),
+    }
+
+
+def _api_features_payload():
+    """Return a concise description of the API surface and storage boundaries."""
+    return {
+        'api': 'v1',
+        'resources': {
+            'notes': {
+                'endpoint': API_NOTES_PATH,
+                'storage': 'client-local',
+                'encryption': 'client-side',
+                'placeholder': True,
+                'allowed_methods': list(API_READ_ONLY_METHODS),
+                'write_methods_disabled': ['POST', 'PUT', 'PATCH', 'DELETE'],
+            },
+            'consent': {
+                'endpoint': API_CONSENT_PATH,
+                'storage': 'client-local',
+                'integrity': 'client-side-sha256',
+                'placeholder': True,
+                'allowed_methods': list(API_READ_ONLY_METHODS),
+                'write_methods_disabled': ['POST', 'PUT', 'PATCH', 'DELETE'],
+            },
+        },
+    }
+
+
+def _read_only_resource_payload(resource_name: str, description: str):
+    """Return metadata for resources that intentionally do not expose server writes."""
+    return {
+        'resource': resource_name,
+        'mode': 'read-only-metadata',
+        'storage': 'browser-local-storage',
+        'allowed_methods': list(API_READ_ONLY_METHODS),
+        'writes_enabled': False,
+        'placeholder': True,
+        'message': description,
+    }
+
+
+def _handle_api_request(request, path):
+    """Handle API routes and enforce read-only semantics where required."""
+    if request.method == 'OPTIONS':
+        if path in ('/api/health', '/api/features'):
+            return cors_response(allow_methods='GET, OPTIONS')
+        if path in (API_NOTES_PATH, API_CONSENT_PATH):
+            return cors_response(allow_methods='GET, OPTIONS')
+        return cors_response(allow_methods='GET, OPTIONS')
+
+    if path == '/api/health':
+        if request.method != 'GET':
+            return method_not_allowed_response(API_READ_ONLY_METHODS)
+        return json_response(_api_health_payload())
+
+    if path == '/api/features':
+        if request.method != 'GET':
+            return method_not_allowed_response(API_READ_ONLY_METHODS)
+        return json_response(_api_features_payload())
+
+    if path == API_NOTES_PATH:
+        # TODO: Replace this placeholder metadata endpoint with a reviewed backend notes contract
+        # only after the privacy model, storage design, and allowed CORS origins are approved.
+        if request.method != 'GET':
+            return method_not_allowed_response(
+                API_READ_ONLY_METHODS,
+                message='Notes API is read-only; POST, PUT, PATCH, and DELETE are disabled.')
+        return json_response(
+            _read_only_resource_payload(
+                'notes',
+                'Notes remain encrypted client-side and stored only in the browser; '
+                'the backend does not create, update, or delete note content.',
+            ))
+
+    if path == API_CONSENT_PATH:
+        # TODO: Replace this placeholder metadata endpoint with a reviewed consent-audit API
+        # only after data-retention rules, storage design, and allowed CORS origins are approved.
+        if request.method != 'GET':
+            return method_not_allowed_response(
+                API_READ_ONLY_METHODS,
+                message='Consent logging API is read-only; POST, PUT, PATCH, and DELETE are disabled.')
+        return json_response(
+            _read_only_resource_payload(
+                'consent',
+                'Consent records remain local to the browser; the backend exposes policy metadata '
+                'but does not write or delete consent log entries.',
+            ))
+
+    return json_error_response('API route not found', status=404, code='not_found')
 
 
 class Default(WorkerEntrypoint):
@@ -24,7 +140,12 @@ class Default(WorkerEntrypoint):
 
         # Handle CORS preflight
         if request.method == 'OPTIONS':
+            if path.startswith('/api/'):
+                return _handle_api_request(request, path)
             return cors_response()
+
+        if path.startswith('/api/'):
+            return _handle_api_request(request, path)
 
         # Handle GET requests for HTML pages
         if request.method == 'GET' and path in PAGES_MAP:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,13 +1,14 @@
 import asyncio
+import importlib
 import json
 import os
 import sys
 from datetime import datetime
+from types import ModuleType
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock
 
-
-mock_workers = MagicMock()
+import pytest
 
 
 class FakeResponse:
@@ -21,16 +22,8 @@ class FakeWorkerEntrypoint:
     pass
 
 
-mock_workers.Response = FakeResponse
-mock_workers.WorkerEntrypoint = FakeWorkerEntrypoint
-sys.modules['workers'] = mock_workers
-
 ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 SRC_ROOT = os.path.join(ROOT, 'src')
-if SRC_ROOT not in sys.path:
-    sys.path.insert(0, SRC_ROOT)
-
-import main  # noqa: E402  pylint: disable=wrong-import-position
 
 
 class FakeRequest:
@@ -39,15 +32,32 @@ class FakeRequest:
         self.method = method
 
 
-def run_fetch(path, method='GET', env=None):
-    app = main.Default()
+@pytest.fixture
+def main_module(monkeypatch):
+    mock_workers = ModuleType('workers')
+    mock_workers.Response = FakeResponse
+    mock_workers.WorkerEntrypoint = FakeWorkerEntrypoint
+
+    monkeypatch.setitem(sys.modules, 'workers', mock_workers)
+    monkeypatch.syspath_prepend(SRC_ROOT)
+    monkeypatch.delitem(sys.modules, 'main', raising=False)
+
+    importlib.invalidate_caches()
+    module = importlib.import_module('main')
+    yield module
+
+    monkeypatch.delitem(sys.modules, 'main', raising=False)
+
+
+def run_fetch(main_module, path, method='GET', env=None):
+    app = main_module.Default()
     request = FakeRequest(f'https://example.com{path}', method=method)
     runtime_env = env if env is not None else SimpleNamespace()
     return asyncio.run(app.on_fetch(request, runtime_env))
 
 
-def test_health_endpoint_returns_service_metadata():
-    response = run_fetch('/api/health')
+def test_health_endpoint_returns_service_metadata(main_module):
+    response = run_fetch(main_module, '/api/health')
 
     assert response.status_code == 200
     assert response.headers['Content-Type'] == 'application/json; charset=utf-8'
@@ -59,14 +69,16 @@ def test_health_endpoint_returns_service_metadata():
     assert datetime.fromisoformat(payload['timestamp'].replace('Z', '+00:00'))
 
 
-def test_features_endpoint_describes_read_only_resources():
-    response = run_fetch('/api/features')
+def test_features_endpoint_describes_read_only_resources(main_module):
+    response = run_fetch(main_module, '/api/features')
 
     assert response.status_code == 200
     payload = json.loads(response.body)
     assert payload['resources']['notes']['placeholder'] is True
+    assert payload['resources']['notes']['storage'] == 'browser-local-storage'
     assert payload['resources']['notes']['allowed_methods'] == ['GET', 'OPTIONS']
     assert payload['resources']['consent']['placeholder'] is True
+    assert payload['resources']['consent']['storage'] == 'browser-local-storage'
     assert payload['resources']['consent']['write_methods_disabled'] == [
         'POST',
         'PUT',
@@ -75,8 +87,8 @@ def test_features_endpoint_describes_read_only_resources():
     ]
 
 
-def test_notes_endpoint_is_read_only_metadata():
-    response = run_fetch('/api/notes')
+def test_notes_endpoint_is_read_only_metadata(main_module):
+    response = run_fetch(main_module, '/api/notes')
 
     assert response.status_code == 200
     payload = json.loads(response.body)
@@ -86,8 +98,8 @@ def test_notes_endpoint_is_read_only_metadata():
     assert payload['storage'] == 'browser-local-storage'
 
 
-def test_consent_endpoint_rejects_post():
-    response = run_fetch('/api/consent', method='POST')
+def test_consent_endpoint_rejects_post(main_module):
+    response = run_fetch(main_module, '/api/consent', method='POST')
 
     assert response.status_code == 405
     assert response.headers['Allow'] == 'GET, OPTIONS'
@@ -96,27 +108,27 @@ def test_consent_endpoint_rejects_post():
     assert payload['allowed_methods'] == ['GET', 'OPTIONS']
 
 
-def test_notes_options_preflight_only_allows_get_and_options():
-    response = run_fetch('/api/notes', method='OPTIONS')
+def test_notes_options_preflight_only_allows_get_and_options(main_module):
+    response = run_fetch(main_module, '/api/notes', method='OPTIONS')
 
     assert response.status_code == 204
     assert response.headers['Access-Control-Allow-Methods'] == 'GET, OPTIONS'
 
 
-def test_unknown_api_route_returns_json_404():
-    response = run_fetch('/api/unknown')
+def test_unknown_api_route_returns_json_404(main_module):
+    response = run_fetch(main_module, '/api/unknown')
 
     assert response.status_code == 404
     payload = json.loads(response.body)
     assert payload['code'] == 'not_found'
 
 
-def test_non_api_routes_still_fall_back_to_assets():
+def test_non_api_routes_still_fall_back_to_assets(main_module):
     asset_response = FakeResponse('asset payload', status=200, headers={'Content-Type': 'text/plain'})
     assets = SimpleNamespace(fetch=AsyncMock(return_value=asset_response))
     env = SimpleNamespace(ASSETS=assets)
 
-    response = run_fetch('/css/main.css', env=env)
+    response = run_fetch(main_module, '/css/main.css', env=env)
 
     assert response is asset_response
     assets.fetch.assert_called_once()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,122 @@
+import asyncio
+import json
+import os
+import sys
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+
+mock_workers = MagicMock()
+
+
+class FakeResponse:
+    def __init__(self, body, status=200, headers=None):
+        self.body = body.encode('utf-8') if isinstance(body, str) else body
+        self.status_code = status
+        self.headers = headers or {}
+
+
+class FakeWorkerEntrypoint:
+    pass
+
+
+mock_workers.Response = FakeResponse
+mock_workers.WorkerEntrypoint = FakeWorkerEntrypoint
+sys.modules['workers'] = mock_workers
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+SRC_ROOT = os.path.join(ROOT, 'src')
+if SRC_ROOT not in sys.path:
+    sys.path.insert(0, SRC_ROOT)
+
+import main  # noqa: E402  pylint: disable=wrong-import-position
+
+
+class FakeRequest:
+    def __init__(self, url, method='GET'):
+        self.url = url
+        self.method = method
+
+
+def run_fetch(path, method='GET', env=None):
+    app = main.Default()
+    request = FakeRequest(f'https://example.com{path}', method=method)
+    runtime_env = env if env is not None else SimpleNamespace()
+    return asyncio.run(app.on_fetch(request, runtime_env))
+
+
+def test_health_endpoint_returns_service_metadata():
+    response = run_fetch('/api/health')
+
+    assert response.status_code == 200
+    assert response.headers['Content-Type'] == 'application/json; charset=utf-8'
+    payload = json.loads(response.body)
+    assert payload['status'] == 'ok'
+    assert payload['service'] == 'blt-safecloak'
+    assert payload['version'] == '0.1.0'
+    assert payload['timestamp'].endswith('Z')
+    assert datetime.fromisoformat(payload['timestamp'].replace('Z', '+00:00'))
+
+
+def test_features_endpoint_describes_read_only_resources():
+    response = run_fetch('/api/features')
+
+    assert response.status_code == 200
+    payload = json.loads(response.body)
+    assert payload['resources']['notes']['placeholder'] is True
+    assert payload['resources']['notes']['allowed_methods'] == ['GET', 'OPTIONS']
+    assert payload['resources']['consent']['placeholder'] is True
+    assert payload['resources']['consent']['write_methods_disabled'] == [
+        'POST',
+        'PUT',
+        'PATCH',
+        'DELETE',
+    ]
+
+
+def test_notes_endpoint_is_read_only_metadata():
+    response = run_fetch('/api/notes')
+
+    assert response.status_code == 200
+    payload = json.loads(response.body)
+    assert payload['resource'] == 'notes'
+    assert payload['placeholder'] is True
+    assert payload['writes_enabled'] is False
+    assert payload['storage'] == 'browser-local-storage'
+
+
+def test_consent_endpoint_rejects_post():
+    response = run_fetch('/api/consent', method='POST')
+
+    assert response.status_code == 405
+    assert response.headers['Allow'] == 'GET, OPTIONS'
+    payload = json.loads(response.body)
+    assert payload['code'] == 'method_not_allowed'
+    assert payload['allowed_methods'] == ['GET', 'OPTIONS']
+
+
+def test_notes_options_preflight_only_allows_get_and_options():
+    response = run_fetch('/api/notes', method='OPTIONS')
+
+    assert response.status_code == 204
+    assert response.headers['Access-Control-Allow-Methods'] == 'GET, OPTIONS'
+
+
+def test_unknown_api_route_returns_json_404():
+    response = run_fetch('/api/unknown')
+
+    assert response.status_code == 404
+    payload = json.loads(response.body)
+    assert payload['code'] == 'not_found'
+
+
+def test_non_api_routes_still_fall_back_to_assets():
+    asset_response = FakeResponse('asset payload', status=200, headers={'Content-Type': 'text/plain'})
+    assets = SimpleNamespace(fetch=AsyncMock(return_value=asset_response))
+    env = SimpleNamespace(ASSETS=assets)
+
+    response = run_fetch('/css/main.css', env=env)
+
+    assert response is asset_response
+    assets.fetch.assert_called_once()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -23,7 +23,7 @@ sys.modules['workers'] = mock_workers
 # Fix the path so it finds your 'src' folder
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 # Now the import will work perfectly!
-from src.libs.utils import html_response, json_response, cors_response
+from src.libs.utils import cors_response, html_response, json_response, method_not_allowed_response
 
 
 def test_html_response():
@@ -77,3 +77,12 @@ def test_json_response_default_str_fallback():
     assert response_data["timestamp"] == "2026-03-22 12:00:00"
     actual_set = set(ast.literal_eval(response_data["unique_items"]))
     assert actual_set == {1, 2, 3}
+
+
+def test_method_not_allowed_response_materializes_iterables():
+    response = method_not_allowed_response(method for method in ("GET", "OPTIONS"))
+
+    assert response.status_code == 405
+    assert response.headers["Allow"] == "GET, OPTIONS"
+    assert response.headers["Access-Control-Allow-Methods"] == "GET, OPTIONS"
+    assert json.loads(response.body)["allowed_methods"] == ["GET", "OPTIONS"]


### PR DESCRIPTION
Adds a structured /api/* router to the Cloudflare Worker with four endpoints:

GET /api/health - machine readable status, version, and UTC timestamp for deploy verification
GET /api/features - documents the current API surface
GET /api/notes and GET /api/consent - explicit read only placeholders (placeholder: true) that document the privacy boundary: no data is stored server-side

Also standardizes JSON 404/405 responses and CORS preflight handling in utils.py.

/api/notes and /api/consent do not persist or mutate data
CORS is temporarily wildcard * must be locked to safecloak.owaspblt.org before any write API ships

All tests passing: pytest tests/test_main.py tests/test_utils.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added REST API: health, features, notes, and consent read-only endpoints with JSON responses and timestamps.
  * Improved CORS preflight handling for API routes.
  * Standardized JSON error responses and explicit 405 method-not-allowed responses including Allow headers and allowed_methods payload.

* **Tests**
  * Added/expanded tests covering the new API endpoints, CORS behavior, and method-not-allowed/error response formatting.

* **Chores**
  * Added package/module docstrings for package clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->