### PR TITLE
 collision-safe consent entry ids and reliable notes save

### DIFF
--- a/public/js/consent.js
+++ b/public/js/consent.js
@@ -18,9 +18,31 @@ const ConsentManager = (() => {
   function load() {
     try {
       const raw = localStorage.getItem(STORAGE_KEY);
-      log = raw ? JSON.parse(raw) : [];
-      if (!Array.isArray(log)) log = [];
-    } catch {
+function load() {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    const parsed = raw ? JSON.parse(raw) : [];
+    if (!Array.isArray(parsed)) {
+      log = [];
+      return;
+    }
+    log = parsed
+      .filter((e) => e && typeof e === "object")
+      .map((e) => ({
+        id: typeof e.id === "string" ? e.id : generateId(),
+        type: typeof e.type === "string" ? e.type : "recorded",
+        name: typeof e.name === "string" ? e.name : "Unnamed event",
+        details: typeof e.details === "string" ? e.details : "",
+        purpose: typeof e.purpose === "string" ? e.purpose : "",
+        participants: Array.isArray(e.participants) ? e.participants : [],
+        timestamp: Number.isFinite(e.timestamp) ? e.timestamp : Date.now(),
+        isoTime: typeof e.isoTime === "string" ? e.isoTime : new Date().toISOString(),
+        hash: typeof e.hash === "string" ? e.hash : "hash-unavailable",
+      }));
+  } catch {
+    log = [];
+  }
+}
       log = [];
     }
   }

--- a/public/js/consent.js
+++ b/public/js/consent.js
@@ -92,12 +92,9 @@ const ConsentManager = (() => {
 
   /* ── Verify a specific entry ── */
   async function verifyEntry(id) {
-    // Previously used log.find() which returns the first match.
-    // With the old timestamp-based ids a collision would cause this to verify
     const matches = log.filter((e) => e.id === id);
     if (matches.length === 0) return showToast("Entry not found", "error");
     if (matches.length > 1) {
-      // Should never happen with crypto-random ids, but handle defensively.
       return showToast("⚠️ Duplicate entry ids detected — log may be corrupted", "error");
     }
     const entry = matches[0];
@@ -120,7 +117,6 @@ const ConsentManager = (() => {
     const before = log.length;
     log = log.filter((e) => e.id !== id);
     if (log.length === before) {
-      // Nothing was removed — id didn't match any entry.
       showToast("Entry not found", "error");
       return;
     }

--- a/public/js/consent.js
+++ b/public/js/consent.js
@@ -7,11 +7,35 @@ const ConsentManager = (() => {
   const STORAGE_KEY = "safecloak_consent_log_v1";
   let log = [];
 
+  /* ── ID generation ──
+   * Previously: Date.now().toString() + Math.random().toString(36).slice(2, 7)
+   *
+   * Bug: Date.now() has millisecond resolution. Two events recorded within the
+   * same millisecond (e.g. rapid consent + session-start during page load) could
+   * produce the same timestamp prefix.  Math.random() adds only ~5 base-36 chars
+   * (~25 bits of entropy), giving a roughly 1-in-33M collision chance per pair —
+   * low but non-zero, and collision would cause verifyEntry() to silently verify
+   * the wrong entry because Array.find() returns the first match.
+   *
+   * Fix: use crypto.getRandomValues() for a 128-bit hex UUID-style token.
+   * This makes collisions astronomically unlikely (1 in 2^128) regardless of
+   * timing, and keeps the id fully opaque and unguessable.
+   */
+  function generateId() {
+    const bytes = new Uint8Array(16);
+    crypto.getRandomValues(bytes);
+    return Array.from(bytes)
+      .map((b) => b.toString(16).padStart(2, "0"))
+      .join("");
+  }
+
   /* ── Load / Save ── */
   function load() {
     try {
       const raw = localStorage.getItem(STORAGE_KEY);
       log = raw ? JSON.parse(raw) : [];
+      // Guard: ensure log is always an array even if storage is corrupted.
+      if (!Array.isArray(log)) log = [];
     } catch {
       log = [];
     }
@@ -29,7 +53,9 @@ const ConsentManager = (() => {
   async function record(event) {
     const ts = Date.now();
     const entry = {
-      id: ts.toString() + Math.random().toString(36).slice(2, 7),
+      // Use crypto-random id instead of timestamp + Math.random() to eliminate
+      // collision risk when multiple events are recorded in the same millisecond.
+      id: generateId(),
       type: event.type || "recorded", // 'given' | 'withdrawn' | 'recorded'
       name: event.name || "Unnamed event",
       details: event.details || "",
@@ -84,8 +110,19 @@ const ConsentManager = (() => {
 
   /* ── Verify a specific entry ── */
   async function verifyEntry(id) {
-    const entry = log.find((e) => e.id === id);
-    if (!entry) return showToast("Entry not found", "error");
+    // Previously used log.find() which returns the first match.
+    // With the old timestamp-based ids a collision would cause this to verify
+    // a different entry's hash against the wrong data, silently returning
+    // "untampered" for a record that was never actually checked.
+    // Now ids are 128-bit random hex strings so collisions cannot occur, but
+    // we still validate that exactly one entry matches to surface any corruption.
+    const matches = log.filter((e) => e.id === id);
+    if (matches.length === 0) return showToast("Entry not found", "error");
+    if (matches.length > 1) {
+      // Should never happen with crypto-random ids, but handle defensively.
+      return showToast("⚠️ Duplicate entry ids detected — log may be corrupted", "error");
+    }
+    const entry = matches[0];
     try {
       const data = `${entry.type}|${entry.name}|${entry.isoTime}|${entry.details}`;
       const hash = await Crypto.sha256(data);
@@ -102,7 +139,13 @@ const ConsentManager = (() => {
   /* ── Delete entry ── */
   function deleteEntry(id) {
     if (!confirm("Delete this consent record? This cannot be undone.")) return;
+    const before = log.length;
     log = log.filter((e) => e.id !== id);
+    if (log.length === before) {
+      // Nothing was removed — id didn't match any entry.
+      showToast("Entry not found", "error");
+      return;
+    }
     save();
     renderLog("consent-log");
     showToast("Consent record deleted", "info");

--- a/public/js/consent.js
+++ b/public/js/consent.js
@@ -6,21 +6,6 @@
 const ConsentManager = (() => {
   const STORAGE_KEY = "safecloak_consent_log_v1";
   let log = [];
-
-  /* ── ID generation ──
-   * Previously: Date.now().toString() + Math.random().toString(36).slice(2, 7)
-   *
-   * Bug: Date.now() has millisecond resolution. Two events recorded within the
-   * same millisecond (e.g. rapid consent + session-start during page load) could
-   * produce the same timestamp prefix.  Math.random() adds only ~5 base-36 chars
-   * (~25 bits of entropy), giving a roughly 1-in-33M collision chance per pair —
-   * low but non-zero, and collision would cause verifyEntry() to silently verify
-   * the wrong entry because Array.find() returns the first match.
-   *
-   * Fix: use crypto.getRandomValues() for a 128-bit hex UUID-style token.
-   * This makes collisions astronomically unlikely (1 in 2^128) regardless of
-   * timing, and keeps the id fully opaque and unguessable.
-   */
   function generateId() {
     const bytes = new Uint8Array(16);
     crypto.getRandomValues(bytes);
@@ -34,7 +19,6 @@ const ConsentManager = (() => {
     try {
       const raw = localStorage.getItem(STORAGE_KEY);
       log = raw ? JSON.parse(raw) : [];
-      // Guard: ensure log is always an array even if storage is corrupted.
       if (!Array.isArray(log)) log = [];
     } catch {
       log = [];

--- a/public/js/consent.js
+++ b/public/js/consent.js
@@ -37,8 +37,6 @@ const ConsentManager = (() => {
   async function record(event) {
     const ts = Date.now();
     const entry = {
-      // Use crypto-random id instead of timestamp + Math.random() to eliminate
-      // collision risk when multiple events are recorded in the same millisecond.
       id: generateId(),
       type: event.type || "recorded", // 'given' | 'withdrawn' | 'recorded'
       name: event.name || "Unnamed event",
@@ -96,10 +94,6 @@ const ConsentManager = (() => {
   async function verifyEntry(id) {
     // Previously used log.find() which returns the first match.
     // With the old timestamp-based ids a collision would cause this to verify
-    // a different entry's hash against the wrong data, silently returning
-    // "untampered" for a record that was never actually checked.
-    // Now ids are 128-bit random hex strings so collisions cannot occur, but
-    // we still validate that exactly one entry matches to surface any corruption.
     const matches = log.filter((e) => e.id === id);
     if (matches.length === 0) return showToast("Entry not found", "error");
     if (matches.length > 1) {

--- a/public/js/consent.js
+++ b/public/js/consent.js
@@ -135,6 +135,10 @@ function load() {
 
   /* ── Delete entry ── */
   function deleteEntry(id) {
+    if (!log.some((e) => e && e.id === id)) {
+      showToast("Entry not found", "error");
+      return;
+    }
     if (!confirm("Delete this consent record? This cannot be undone.")) return;
     const before = log.length;
     log = log.filter((e) => e.id !== id);

--- a/public/js/consent.js
+++ b/public/js/consent.js
@@ -95,7 +95,7 @@ const ConsentManager = (() => {
     const matches = log.filter((e) => e.id === id);
     if (matches.length === 0) return showToast("Entry not found", "error");
     if (matches.length > 1) {
-      return showToast(" Duplicate entry ids detected — log may be corrupted", "error");
+      return showToast("Duplicate entry ids detected — log may be corrupted", "error");
     }
     const entry = matches[0];
     try {

--- a/public/js/consent.js
+++ b/public/js/consent.js
@@ -95,7 +95,7 @@ const ConsentManager = (() => {
     const matches = log.filter((e) => e.id === id);
     if (matches.length === 0) return showToast("Entry not found", "error");
     if (matches.length > 1) {
-      return showToast("⚠️ Duplicate entry ids detected — log may be corrupted", "error");
+      return showToast(" Duplicate entry ids detected — log may be corrupted", "error");
     }
     const entry = matches[0];
     try {

--- a/public/js/notes.js
+++ b/public/js/notes.js
@@ -145,9 +145,6 @@ const NotesApp = (() => {
   }
 
   function scheduleSave() {
-    // Debounce writes so rapid keystrokes do not flood the crypto API.
-    // The beforeunload flush (registered in init) ensures the final edit is
-    // persisted even if the user closes the tab before the 800 ms timer fires.
     clearTimeout(saveTimer);
     saveTimer = setTimeout(() => {
       saveNotes();
@@ -353,15 +350,8 @@ const NotesApp = (() => {
     await loadNotes();
     renderNotesList();
     if (notes.length > 0) setActiveNote(notes[0].id);
-
-    // Flush any pending debounced save when the tab is closed or navigated away.
-    // Without this, the last keystroke within the 800 ms debounce window would be
-    // lost because the setTimeout fires after the page unloads.
     window.addEventListener("beforeunload", () => {
       clearTimeout(saveTimer);
-      // saveNotes() is async but beforeunload cannot await it; we call it
-      // fire-and-forget. Modern browsers give async tasks a short grace period
-      // on unload, so this succeeds in practice for the lightweight crypto write.
       saveNotes();
     });
 

--- a/public/js/notes.js
+++ b/public/js/notes.js
@@ -77,10 +77,6 @@ const NotesApp = (() => {
   }
 
   async function saveNotes() {
-    // Previously the catch block only logged to console, so a save failure
-    // (e.g. localStorage quota exceeded or crypto error) was invisible to the
-    // user. Notes could be silently lost on the next page load.
-    // Fix: surface a toast so the user knows to export their notes manually.
     try {
       await Crypto.saveEncrypted(STORAGE_KEY, notes, getPassphrase());
     } catch (err) {

--- a/public/js/notes.js
+++ b/public/js/notes.js
@@ -350,10 +350,19 @@ const NotesApp = (() => {
     await loadNotes();
     renderNotesList();
     if (notes.length > 0) setActiveNote(notes[0].id);
-    window.addEventListener("beforeunload", () => {
-      clearTimeout(saveTimer);
-      saveNotes();
+    const flushPendingSave = () => {
+      if (saveTimer) {
+        clearTimeout(saveTimer);
+        saveTimer = null;
+      }
+      void saveNotes();
+    };
+
+    document.addEventListener("visibilitychange", () => {
+      if (document.visibilityState === "hidden") flushPendingSave();
     });
+    window.addEventListener("pagehide", flushPendingSave);
+    window.addEventListener("beforeunload", flushPendingSave);
 
     // Wire up editor inputs
     const titleEl = document.getElementById("note-title");

--- a/public/js/notes.js
+++ b/public/js/notes.js
@@ -77,10 +77,15 @@ const NotesApp = (() => {
   }
 
   async function saveNotes() {
+    // Previously the catch block only logged to console, so a save failure
+    // (e.g. localStorage quota exceeded or crypto error) was invisible to the
+    // user. Notes could be silently lost on the next page load.
+    // Fix: surface a toast so the user knows to export their notes manually.
     try {
       await Crypto.saveEncrypted(STORAGE_KEY, notes, getPassphrase());
     } catch (err) {
       console.error("Failed to save notes:", err);
+      showToast("⚠️ Notes could not be saved — storage may be full. Export your notes to avoid losing them.", "error", 6000);
     }
   }
 
@@ -144,6 +149,9 @@ const NotesApp = (() => {
   }
 
   function scheduleSave() {
+    // Debounce writes so rapid keystrokes do not flood the crypto API.
+    // The beforeunload flush (registered in init) ensures the final edit is
+    // persisted even if the user closes the tab before the 800 ms timer fires.
     clearTimeout(saveTimer);
     saveTimer = setTimeout(() => {
       saveNotes();
@@ -349,6 +357,17 @@ const NotesApp = (() => {
     await loadNotes();
     renderNotesList();
     if (notes.length > 0) setActiveNote(notes[0].id);
+
+    // Flush any pending debounced save when the tab is closed or navigated away.
+    // Without this, the last keystroke within the 800 ms debounce window would be
+    // lost because the setTimeout fires after the page unloads.
+    window.addEventListener("beforeunload", () => {
+      clearTimeout(saveTimer);
+      // saveNotes() is async but beforeunload cannot await it; we call it
+      // fire-and-forget. Modern browsers give async tasks a short grace period
+      // on unload, so this succeeds in practice for the lightweight crypto write.
+      saveNotes();
+    });
 
     // Wire up editor inputs
     const titleEl = document.getElementById("note-title");


### PR DESCRIPTION
consent.js — ID collision risk in record()

The entry id was built from Date.now() (ms resolution) concatenated with five base-36 chars from Math.random() (~25 bits of entropy). Two events recorded in the same millisecond could produce identical ids. When that happened, verifyEntry() called log.find() and silently verified the wrong entry's hash, returning 'untampered' for a record that was never actually checked. deleteEntry() had the same flaw — log.filter() removed the first matching id, potentially deleting the wrong record.

Fix: replace the timestamp+random scheme with crypto.getRandomValues() producing a 128-bit hex token. Collision probability is now ~1 in 2^128 regardless of call timing.

verifyEntry() now uses log.filter() instead of log.find() and errors if more than one match is found, making any future id corruption visible rather than silently wrong.

deleteEntry() now checks whether the filter actually removed an entry and shows an error toast if the id was not found, instead of silently doing nothing.

The load() guard (Array.isArray check) ensures a corrupted localStorage value cannot put the log into a non-array state and cause downstream map/filter calls to throw.

notes.js — silent save failure and last-edit loss on tab close

saveNotes() swallowed crypto and storage errors with only a console log, leaving the user with no indication that their notes were not persisted. A localStorage quota error would silently drop every subsequent edit.

Fix: surface a persistent error toast when saveNotes() rejects so the user knows to export their notes before closing the tab.

A beforeunload listener now flushes the debounced save timer immediately when the tab is closed or navigated away. Without it, any edit made in the last 800 ms of the debounce window was dropped because the setTimeout never fired after page unload.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consent log robustness: safer ID generation, normalization/reset of corrupted data, detection of duplicate IDs with clear error messaging, and reliable feedback when deletes find no matching entry.
* **New Features**
  * Notes now show a user-facing error toast on save failures with advice to export.
  * Notes are automatically persisted when leaving or hiding the page to reduce data loss.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->