### PR TITLE
feat(api): add  room validation endpoints

### DIFF
--- a/public/js/video.js
+++ b/public/js/video.js
@@ -488,6 +488,21 @@ const VideoChat = (() => {
       return;
     }
 
+    // Validate room ID with backend before initiating WebRTC connection
+    try {
+      const response = await fetch(`/api/rooms/validate?room=${encodeURIComponent(remotePeerId)}`);
+      const data = await response.json();
+
+      if (!data.ok || !data.isValid) {
+        showToast("Backend rejected room ID — check format and try again", "error");
+        return;
+      }
+    } catch (err) {
+      // Network error or backend down — warn but allow P2P attempt to continue
+      console.warn("Backend validation failed:", err);
+      showToast("Warning: Could not validate room with server, proceeding offline", "warning");
+    }
+
     if (remotePeerId === state.peerId) {
       showToast("You cannot call yourself", "warning");
       return;

--- a/public/js/video.js
+++ b/public/js/video.js
@@ -487,6 +487,7 @@ const VideoChat = (() => {
       showToast("Room ID must be exactly 6 characters using only uppercase letters (A-Z except I,O) and digits (2-9)", "error");
       return;
     }
+
     if (remotePeerId === state.peerId) {
       showToast("You cannot call yourself", "warning");
       return;

--- a/src/main.py
+++ b/src/main.py
@@ -15,7 +15,7 @@ PAGES_MAP = {
     '/consent': 'consent.html',
 }
 
-API_PREFIX = '/api/'
+API_PREFIX = '/api'
 ROOM_ID_PATTERN = re.compile(r'^[ABCDEFGHJKLMNPQRSTUVWXYZ23456789]{6}$')
 
 
@@ -48,7 +48,7 @@ class Default(WorkerEntrypoint):
             return cors_response()
 
         # Basic JSON APIs
-        if path.startswith(API_PREFIX):
+        if path == API_PREFIX or path.startswith(API_PREFIX + '/'):
             if request.method != 'GET':
                 return self._json_error(
                     status=405,

--- a/src/main.py
+++ b/src/main.py
@@ -2,7 +2,6 @@
 from workers import WorkerEntrypoint, Response
 from urllib.parse import parse_qs, urlparse
 from pathlib import Path
-from datetime import datetime, timezone
 import re
 
 from src.libs.utils import cors_response, html_response, json_response
@@ -23,17 +22,6 @@ class Default(WorkerEntrypoint):
     """Worker entrypoint for handling HTTP requests and serving content."""
 
     @staticmethod
-    def _json_error(status: int, code: str, message: str) -> Response:
-        """Return a consistent JSON error payload for API endpoints."""
-        return json_response({
-            'ok': False,
-            'error': {
-                'code': code,
-                'message': message,
-            },
-        }, status=status)
-
-    @staticmethod
     def _validate_room_id(room_id: str) -> bool:
         """Validate room IDs using the same format as the frontend."""
         return bool(ROOM_ID_PATTERN.fullmatch(room_id.strip()))
@@ -49,30 +37,27 @@ class Default(WorkerEntrypoint):
 
         # Basic JSON APIs
         if path == API_PREFIX or path.startswith(API_PREFIX + '/'):
-            if request.method != 'GET':
-                return self._json_error(
-                    status=405,
-                    code='method_not_allowed',
-                    message='Only GET is supported for this endpoint.',
-                )
-
-            if path == '/api/health':
-                return json_response({
-                    'ok': True,
-                    'service': 'blt-safecloak',
-                    'timestamp': datetime.now(timezone.utc).isoformat(),
-                })
-
             if path == '/api/rooms/validate':
+                if request.method != 'GET':
+                    return json_response({
+                        'ok': False,
+                        'error': {
+                            'code': 'method_not_allowed',
+                            'message': 'Only GET is supported for this endpoint.',
+                        },
+                    }, status=405)
+
                 query = parse_qs(url.query)
                 room_id = query.get('room', [''])[0].strip()
 
                 if not room_id:
-                    return self._json_error(
-                        status=400,
-                        code='missing_room_id',
-                        message="Query parameter 'room' is required.",
-                    )
+                    return json_response({
+                        'ok': False,
+                        'error': {
+                            'code': 'missing_room_id',
+                            'message': "Query parameter 'room' is required.",
+                        },
+                    }, status=400)
 
                 return json_response({
                     'ok': True,
@@ -80,11 +65,13 @@ class Default(WorkerEntrypoint):
                     'isValid': self._validate_room_id(room_id),
                 })
 
-            return self._json_error(
-                status=404,
-                code='api_not_found',
-                message='API endpoint not found.',
-            )
+            return json_response({
+                'ok': False,
+                'error': {
+                    'code': 'api_not_found',
+                    'message': 'API endpoint not found.',
+                },
+            }, status=404)
 
         # Handle GET requests for HTML pages
         if request.method == 'GET' and path in PAGES_MAP:

--- a/src/main.py
+++ b/src/main.py
@@ -1,9 +1,11 @@
 # pylint: disable=too-few-public-methods
 from workers import WorkerEntrypoint, Response
-from urllib.parse import urlparse
+from urllib.parse import parse_qs, urlparse
 from pathlib import Path
+from datetime import datetime, timezone
+import re
 
-from libs.utils import html_response, cors_response
+from libs.utils import cors_response, html_response, json_response
 
 # Route to HTML page mapping
 PAGES_MAP = {
@@ -13,9 +15,28 @@ PAGES_MAP = {
     '/consent': 'consent.html',
 }
 
+API_PREFIX = '/api/'
+ROOM_ID_PATTERN = re.compile(r'^[ABCDEFGHJKLMNPQRSTUVWXYZ23456789]{6}$')
+
 
 class Default(WorkerEntrypoint):
     """Worker entrypoint for handling HTTP requests and serving content."""
+
+    @staticmethod
+    def _json_error(status: int, code: str, message: str) -> Response:
+        """Return a consistent JSON error payload for API endpoints."""
+        return json_response({
+            'ok': False,
+            'error': {
+                'code': code,
+                'message': message,
+            },
+        }, status=status)
+
+    @staticmethod
+    def _validate_room_id(room_id: str) -> bool:
+        """Validate room IDs using the same format as the frontend."""
+        return bool(ROOM_ID_PATTERN.fullmatch(room_id.strip()))
 
     async def on_fetch(self, request, env):
         """Handle incoming HTTP requests and route them to the appropriate response."""
@@ -25,6 +46,45 @@ class Default(WorkerEntrypoint):
         # Handle CORS preflight
         if request.method == 'OPTIONS':
             return cors_response()
+
+        # Basic JSON APIs
+        if path.startswith(API_PREFIX):
+            if request.method != 'GET':
+                return self._json_error(
+                    status=405,
+                    code='method_not_allowed',
+                    message='Only GET is supported for this endpoint.',
+                )
+
+            if path == '/api/health':
+                return json_response({
+                    'ok': True,
+                    'service': 'blt-safecloak',
+                    'timestamp': datetime.now(timezone.utc).isoformat(),
+                })
+
+            if path == '/api/rooms/validate':
+                query = parse_qs(url.query)
+                room_id = query.get('room', [''])[0].strip()
+
+                if not room_id:
+                    return self._json_error(
+                        status=400,
+                        code='missing_room_id',
+                        message="Query parameter 'room' is required.",
+                    )
+
+                return json_response({
+                    'ok': True,
+                    'roomId': room_id,
+                    'isValid': self._validate_room_id(room_id),
+                })
+
+            return self._json_error(
+                status=404,
+                code='api_not_found',
+                message='API endpoint not found.',
+            )
 
         # Handle GET requests for HTML pages
         if request.method == 'GET' and path in PAGES_MAP:

--- a/src/main.py
+++ b/src/main.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from datetime import datetime, timezone
 import re
 
-from libs.utils import cors_response, html_response, json_response
+from src.libs.utils import cors_response, html_response, json_response
 
 # Route to HTML page mapping
 PAGES_MAP = {

--- a/tests/test_main_api.py
+++ b/tests/test_main_api.py
@@ -1,0 +1,94 @@
+import asyncio
+import json
+import os
+import sys
+from types import SimpleNamespace
+
+# Provide a minimal workers module for local test execution.
+class FakeResponse:
+    def __init__(self, body, status=200, headers=None):
+        self.body = body.encode("utf-8") if isinstance(body, str) else body
+        self.status_code = status
+        self.headers = headers or {}
+
+
+class FakeWorkerEntrypoint:
+    pass
+
+
+sys.modules["workers"] = SimpleNamespace(Response=FakeResponse, WorkerEntrypoint=FakeWorkerEntrypoint)
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from src.main import Default  # noqa: E402
+
+
+class FakeRequest:
+    def __init__(self, url: str, method: str = "GET"):
+        self.url = url
+        self.method = method
+
+
+class FakeEnv:
+    pass
+
+
+def _run(request: FakeRequest):
+    return asyncio.run(Default().on_fetch(request, FakeEnv()))
+
+
+def _json(response):
+    return json.loads(response.body.decode("utf-8"))
+
+
+def test_api_health_returns_ok_payload():
+    response = _run(FakeRequest("https://example.com/api/health"))
+
+    assert response.status_code == 200
+    assert response.headers["Content-Type"] == "application/json; charset=utf-8"
+    payload = _json(response)
+    assert payload["ok"] is True
+    assert payload["service"] == "blt-safecloak"
+    assert "timestamp" in payload
+
+
+def test_api_room_validation_valid_id():
+    response = _run(FakeRequest("https://example.com/api/rooms/validate?room=ABC234"))
+
+    assert response.status_code == 200
+    payload = _json(response)
+    assert payload == {"ok": True, "roomId": "ABC234", "isValid": True}
+
+
+def test_api_room_validation_missing_param_returns_400():
+    response = _run(FakeRequest("https://example.com/api/rooms/validate"))
+
+    assert response.status_code == 400
+    payload = _json(response)
+    assert payload["ok"] is False
+    assert payload["error"]["code"] == "missing_room_id"
+
+
+def test_api_room_validation_invalid_id_returns_false():
+    response = _run(FakeRequest("https://example.com/api/rooms/validate?room=ABCD12"))
+
+    assert response.status_code == 200
+    payload = _json(response)
+    assert payload == {"ok": True, "roomId": "ABCD12", "isValid": False}
+
+
+def test_api_unknown_path_returns_json_404():
+    response = _run(FakeRequest("https://example.com/api/unknown"))
+
+    assert response.status_code == 404
+    payload = _json(response)
+    assert payload["ok"] is False
+    assert payload["error"]["code"] == "api_not_found"
+
+
+def test_api_wrong_method_returns_json_405():
+    response = _run(FakeRequest("https://example.com/api/health", method="POST"))
+
+    assert response.status_code == 405
+    payload = _json(response)
+    assert payload["ok"] is False
+    assert payload["error"]["code"] == "method_not_allowed"

--- a/tests/test_main_api.py
+++ b/tests/test_main_api.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 import os
 import sys
+import pytest
 from types import SimpleNamespace
 
 # Provide a minimal workers module for local test execution.
@@ -32,6 +33,9 @@ class FakeEnv:
     pass
 
 
+VALIDATE_URL = "https://example.com/api/rooms/validate"
+
+
 def _run(request: FakeRequest):
     return asyncio.run(Default().on_fetch(request, FakeEnv()))
 
@@ -40,55 +44,65 @@ def _json(response):
     return json.loads(response.body.decode("utf-8"))
 
 
-def test_api_health_returns_ok_payload():
-    response = _run(FakeRequest("https://example.com/api/health"))
-
-    assert response.status_code == 200
-    assert response.headers["Content-Type"] == "application/json; charset=utf-8"
+def _assert_json_error(response, *, status_code: int, error_code: str):
+    assert response.status_code == status_code
     payload = _json(response)
-    assert payload["ok"] is True
-    assert payload["service"] == "blt-safecloak"
-    assert "timestamp" in payload
+    assert payload["ok"] is False
+    assert payload["error"]["code"] == error_code
 
 
-def test_api_room_validation_valid_id():
-    response = _run(FakeRequest("https://example.com/api/rooms/validate?room=ABC234"))
+def test_api_room_validation_get_valid_id():
+    response = _run(FakeRequest(f"{VALIDATE_URL}?room=ABC234"))
 
     assert response.status_code == 200
     payload = _json(response)
     assert payload == {"ok": True, "roomId": "ABC234", "isValid": True}
 
 
-def test_api_room_validation_missing_param_returns_400():
-    response = _run(FakeRequest("https://example.com/api/rooms/validate"))
+def test_api_room_validation_get_missing_param_returns_400():
+    response = _run(FakeRequest(VALIDATE_URL))
 
-    assert response.status_code == 400
-    payload = _json(response)
-    assert payload["ok"] is False
-    assert payload["error"]["code"] == "missing_room_id"
+    _assert_json_error(response, status_code=400, error_code="missing_room_id")
 
 
-def test_api_room_validation_invalid_id_returns_false():
-    response = _run(FakeRequest("https://example.com/api/rooms/validate?room=ABCD12"))
+@pytest.mark.parametrize("room_id", ["ABCD12", "abc234", "I1O0QZ", "ABCDE", "ABCDEFG"])
+def test_api_room_validation_get_invalid_ids_return_false(room_id):
+    response = _run(FakeRequest(f"{VALIDATE_URL}?room={room_id}"))
 
     assert response.status_code == 200
     payload = _json(response)
-    assert payload == {"ok": True, "roomId": "ABCD12", "isValid": False}
+    assert payload == {"ok": True, "roomId": room_id, "isValid": False}
+
+
+def test_api_room_validation_get_strips_whitespace():
+    response = _run(FakeRequest(f"{VALIDATE_URL}?room=%20ABC234%20"))
+
+    assert response.status_code == 200
+    payload = _json(response)
+    assert payload == {"ok": True, "roomId": "ABC234", "isValid": True}
+
+
+@pytest.mark.parametrize("method", ["POST", "PUT", "DELETE", "PATCH"])
+def test_api_room_validation_non_get_returns_json_405(method):
+    response = _run(FakeRequest(VALIDATE_URL, method=method))
+
+    _assert_json_error(response, status_code=405, error_code="method_not_allowed")
 
 
 def test_api_unknown_path_returns_json_404():
     response = _run(FakeRequest("https://example.com/api/unknown"))
 
-    assert response.status_code == 404
-    payload = _json(response)
-    assert payload["ok"] is False
-    assert payload["error"]["code"] == "api_not_found"
+    _assert_json_error(response, status_code=404, error_code="api_not_found")
 
 
-def test_api_wrong_method_returns_json_405():
-    response = _run(FakeRequest("https://example.com/api/health", method="POST"))
+def test_api_base_path_returns_json_404():
+    response = _run(FakeRequest("https://example.com/api"))
 
-    assert response.status_code == 405
-    payload = _json(response)
-    assert payload["ok"] is False
-    assert payload["error"]["code"] == "method_not_allowed"
+    _assert_json_error(response, status_code=404, error_code="api_not_found")
+
+
+def test_options_preflight_returns_cors_response():
+    response = _run(FakeRequest(VALIDATE_URL, method="OPTIONS"))
+
+    assert response.status_code == 204
+    assert "Access-Control-Allow-Methods" in response.headers


### PR DESCRIPTION
## Summary
This PR adds and refines the room validation API flow and its test coverage.

## What Changed
1. Added `GET /api/rooms/validate?room=<ROOM_ID>` for room code validation.
2. Enforced method handling on validation route:
   1. Returns `405` with `method_not_allowed` for non-GET methods.
3. Added/kept input validation behavior:
   1. Returns `400` with `missing_room_id` when `room` is not provided.
   2. Returns `200` with `isValid` for provided room values.
4. Kept API error contract for non-matching API paths:
   1. Returns `404` with `api_not_found`.
5. Refactored API tests for clarity and maintainability:
   1. Added reusable helpers for JSON/error assertions.
   2. Added parameterized coverage for invalid room IDs.
   3. Added parameterized coverage for non-GET methods.
   4. Added coverage for whitespace-trimmed room IDs.
   5. Added coverage for base `/api` and unknown API paths.
   6. Added coverage for `OPTIONS` preflight/CORS response.

## Testing
1. Ran API tests locally.
2. All tests passed.