### PR TITLE
fix: include purpose and participants in consent integrity hash (#70)

### DIFF
--- a/public/js/consent.js
+++ b/public/js/consent.js
@@ -41,7 +41,10 @@ const ConsentManager = (() => {
     };
     // Create a tamper-evident hash of the entry data
     try {
-      const data = `${entry.type}|${entry.name}|${entry.isoTime}|${entry.details}`;
+      const participantsStr = Array.isArray(entry.participants)
+        ? entry.participants.slice().sort().join(",")
+        : String(entry.participants);
+      const data = `${entry.type}|${entry.name}|${entry.isoTime}|${entry.details}|${entry.purpose}|${participantsStr}`;
       entry.hash = await Crypto.sha256(data);
     } catch {
       entry.hash = "hash-unavailable";
@@ -87,7 +90,10 @@ const ConsentManager = (() => {
     const entry = log.find((e) => e.id === id);
     if (!entry) return showToast("Entry not found", "error");
     try {
-      const data = `${entry.type}|${entry.name}|${entry.isoTime}|${entry.details}`;
+      const participantsStr = Array.isArray(entry.participants)
+        ? entry.participants.slice().sort().join(",")
+        : String(entry.participants);
+      const data = `${entry.type}|${entry.name}|${entry.isoTime}|${entry.details}|${entry.purpose}|${participantsStr}`;
       const hash = await Crypto.sha256(data);
       if (hash === entry.hash) {
         showToast("✅ Entry integrity verified — untampered", "success");

--- a/public/js/consent.js
+++ b/public/js/consent.js
@@ -25,27 +25,39 @@ const ConsentManager = (() => {
     }
   }
 
+  function buildHashPayload(entry) {
+    return JSON.stringify({
+      type: (entry.type || "").trim(),
+      name: (entry.name || "").trim(),
+      isoTime: (entry.isoTime || "").trim(),
+      details: (entry.details || "").trim(),
+      purpose: (entry.purpose || "").trim(),
+      participants: Array.isArray(entry.participants)
+        ? entry.participants.map((p) => String(p).trim()).sort()
+        : [],
+    });
+  }
+
   /* ── Record a consent event ── */
   async function record(event) {
     const ts = Date.now();
     const entry = {
       id: ts.toString() + Math.random().toString(36).slice(2, 7),
-      type: event.type || "recorded", // 'given' | 'withdrawn' | 'recorded'
-      name: event.name || "Unnamed event",
-      details: event.details || "",
-      purpose: event.purpose || "",
-      participants: event.participants || [],
+      type: (event.type || "recorded").trim(), // 'given' | 'withdrawn' | 'recorded'
+      name: (event.name || "Unnamed event").trim(),
+      details: (event.details || "").trim(),
+      purpose: (event.purpose || "").trim(),
+      participants: Array.isArray(event.participants)
+        ? event.participants.map((p) => String(p).trim())
+        : [],
       timestamp: ts,
       isoTime: new Date(ts).toISOString(),
       userAgent: navigator.userAgent.slice(0, 100),
+      hashVersion: 2,
     };
     // Create a tamper-evident hash of the entry data
     try {
-      const participantsStr = Array.isArray(entry.participants)
-        ? entry.participants.slice().sort().join(",")
-        : String(entry.participants);
-      const data = `${entry.type}|${entry.name}|${entry.isoTime}|${entry.details}|${entry.purpose}|${participantsStr}`;
-      entry.hash = await Crypto.sha256(data);
+      entry.hash = await Crypto.sha256(buildHashPayload(entry));
     } catch {
       entry.hash = "hash-unavailable";
     }
@@ -90,11 +102,15 @@ const ConsentManager = (() => {
     const entry = log.find((e) => e.id === id);
     if (!entry) return showToast("Entry not found", "error");
     try {
-      const participantsStr = Array.isArray(entry.participants)
-        ? entry.participants.slice().sort().join(",")
-        : String(entry.participants);
-      const data = `${entry.type}|${entry.name}|${entry.isoTime}|${entry.details}|${entry.purpose}|${participantsStr}`;
-      const hash = await Crypto.sha256(data);
+      let payload;
+      if (!entry.hashVersion) {
+       
+        payload = `${entry.type}|${entry.name}|${entry.isoTime}|${entry.details}`;
+      } else {
+    
+        payload = buildHashPayload(entry);
+      }
+      const hash = await Crypto.sha256(payload);
       if (hash === entry.hash) {
         showToast("✅ Entry integrity verified — untampered", "success");
       } else {

--- a/public/js/consent.js
+++ b/public/js/consent.js
@@ -25,16 +25,22 @@ const ConsentManager = (() => {
     }
   }
 
+  function normalizeText(value, fallback = "") {
+    const normalized = value == null ? "" : String(value).trim();
+    return normalized || fallback;
+  }
+
   function buildHashPayload(entry) {
     return JSON.stringify({
-      type: (entry.type || "").trim(),
-      name: (entry.name || "").trim(),
-      isoTime: (entry.isoTime || "").trim(),
-      details: (entry.details || "").trim(),
-      purpose: (entry.purpose || "").trim(),
+      type: normalizeText(entry.type),
+      name: normalizeText(entry.name),
+      isoTime: normalizeText(entry.isoTime),
+      details: normalizeText(entry.details),
+      purpose: normalizeText(entry.purpose),
       participants: Array.isArray(entry.participants)
         ? entry.participants.map((p) => String(p).trim()).sort()
         : [],
+      timestamp: entry.timestamp ?? null,
     });
   }
 
@@ -43,10 +49,10 @@ const ConsentManager = (() => {
     const ts = Date.now();
     const entry = {
       id: ts.toString() + Math.random().toString(36).slice(2, 7),
-      type: (event.type || "recorded").trim(), // 'given' | 'withdrawn' | 'recorded'
-      name: (event.name || "Unnamed event").trim(),
-      details: (event.details || "").trim(),
-      purpose: (event.purpose || "").trim(),
+      type: normalizeText(event.type, "recorded"), // 'given' | 'withdrawn' | 'recorded'
+      name: normalizeText(event.name, "Unnamed event"),
+      details: normalizeText(event.details),
+      purpose: normalizeText(event.purpose),
       participants: Array.isArray(event.participants)
         ? event.participants.map((p) => String(p).trim())
         : [],
@@ -112,7 +118,14 @@ const ConsentManager = (() => {
       }
       const hash = await Crypto.sha256(payload);
       if (hash === entry.hash) {
-        showToast("✅ Entry integrity verified — untampered", "success");
+        if (!entry.hashVersion) {
+          showToast(
+            "⚠️ Legacy entry verified (pre-upgrade) — purpose & participants not covered by this hash",
+            "info"
+          );
+        } else {
+          showToast("✅ Entry integrity verified — untampered", "success");
+        }
       } else {
         showToast("⚠️ Hash mismatch — entry may have been tampered with!", "error");
       }


### PR DESCRIPTION
The SHA-256 hash used for tamper-evidence only covered type, name, isoTime, and details. The purpose and participants fields were stored in each consent entry but excluded from the hash, so an attacker could silently modify those fields in localStorage and verifyEntry() would still report the entry as untampered.

Fix: extend the hash input string in both record() and verifyEntry() to include purpose and the sorted, comma-joined participants list. Participants are sorted before joining so that reordering the array does not produce a false mismatch. #70 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced consent record integrity verification to reliably validate both existing and newly recorded entries.
  * Improved data normalization for consent entries, including standardized handling of participant information and metadata.
  * Strengthened backward compatibility for historical consent records while maintaining data integrity standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->