### PR TITLE
Add explicit UTF-8 encoding to HTML file reading

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -30,7 +30,7 @@ class Default(WorkerEntrypoint):
         # Handle GET requests for HTML pages
         if request.method == 'GET' and path in PAGES_MAP:
             html_path = Path(__file__).parent / 'pages' / PAGES_MAP[path]
-            html_content = html_path.read_text()
+            html_content = html_path.read_text(encoding='utf-8')
             return html_response(html_content)
 
         # Serving static files from the 'public' directory


### PR DESCRIPTION
Ensure HTML files are read using UTF-8 encoding instead of relying on the system default.
This prevents potential decoding issues and ensures consistent behavior 
across different environments. Non-breaking change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed character encoding for HTML page content to ensure proper display of special characters and international text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->