### PR TITLE
fix(video): repair end-call teardown and navigation

### DIFF
--- a/public/js/video.js
+++ b/public/js/video.js
@@ -2042,7 +2042,6 @@ const VideoChat = (() => {
           /* ignore VoiceChanger destroy failures */
         }
       }
-      }
     });
 
     // pagehide is more reliable than beforeunload for cleanup across mobile and desktop.

--- a/public/js/video.js
+++ b/public/js/video.js
@@ -29,6 +29,8 @@ const VideoChat = (() => {
   let speakingAudioContext = null;
   let localSpeakingUntil = 0;
   const lastProfileBroadcastAt = new Map(); // peerId -> timestamp
+  let navigationInProgress = false;
+  let isEndingCall = false;
 
   const state = {
     peerId: null,
@@ -55,6 +57,16 @@ const VideoChat = (() => {
     const textNode = document.createTextNode(text);
     el.appendChild(textNode);
     el.className = `text-${type}`;
+  }
+
+  function navigateToHome() {
+    if (navigationInProgress) return;
+    navigationInProgress = true;
+    try {
+      window.location.assign("/");
+    } catch {
+      window.location.href = "/";
+    }
   }
 
   function setStatusIcon(status) {
@@ -932,12 +944,16 @@ const VideoChat = (() => {
       if (wrapper) wrapper.remove();
       if (activeCalls.size === 0) {
         state.connected = false;
-        updateStatus("fa-solid fa-phone-slash", "Call ended", "muted");
-        setStatusIcon("offline");
-        if ($("call-controls")) {
-          $("btn-noise") && $("btn-noise").classList.add("hidden");
-          $("btn-screen") && $("btn-screen").classList.add("hidden");
-          $("btn-end") && $("btn-end").classList.add("hidden");
+        // Only show remote-disconnect UI if this is not a local teardown
+        if (!isEndingCall) {
+          updateStatus("fa-solid fa-phone-slash", "Call ended", "muted");
+          setStatusIcon("offline");
+          if ($("call-controls")) {
+            $("btn-noise") && $("btn-noise").classList.add("hidden");
+            $("btn-screen") && $("btn-screen").classList.add("hidden");
+            $("btn-end") && $("btn-end").classList.remove("hidden");
+          }
+          showToast("Participant disconnected. Use End Call to return home.", "info");
         }
       } else {
         const count = activeCalls.size;
@@ -1225,10 +1241,25 @@ const VideoChat = (() => {
     }
   }
 
-  function endCall() {
-    activeCalls.forEach((call) => call.close());
+  async function endCall(options = {}) {
+    const { keepEndControlVisible = false } = options;
+    isEndingCall = true;
+
+    activeCalls.forEach((call) => {
+      try {
+        call.close();
+      } catch {
+        /* ignore close failures */
+      }
+    });
     activeCalls.clear();
-    activeDataConns.forEach((conn) => conn.close());
+    activeDataConns.forEach((conn) => {
+      try {
+        conn.close();
+      } catch {
+        /* ignore close failures */
+      }
+    });
     activeDataConns.clear();
     lastProfileBroadcastAt.clear();
     peerProfiles.clear();
@@ -1246,7 +1277,11 @@ const VideoChat = (() => {
     if ($("call-controls")) {
       $("btn-noise") && $("btn-noise").classList.add("hidden");
       $("btn-screen") && $("btn-screen").classList.add("hidden");
-      $("btn-end") && $("btn-end").classList.add("hidden");
+      if (keepEndControlVisible) {
+        $("btn-end") && $("btn-end").classList.remove("hidden");
+      } else {
+        $("btn-end") && $("btn-end").classList.add("hidden");
+      }
     }
     updateParticipantsList();
     showToast("Call ended", "info");
@@ -1257,13 +1292,24 @@ const VideoChat = (() => {
         name: "Call session ended",
         details: `Session ID: ${state.sessionId} — ended at ${new Date().toISOString()}`,
       });
+    isEndingCall = false;
   }
 
-  function hangup() {
-    endCall();
+  async function hangup(options = {}) {
+    const { navigateHome = true } = options;
+
+    await endCall();
     if (peer) {
-      peer.disconnect();
-      peer.destroy();
+      try {
+        peer.disconnect();
+      } catch {
+        /* ignore disconnect failures */
+      }
+      try {
+        peer.destroy();
+      } catch {
+        /* ignore destroy failures */
+      }
       peer = null;
     }
     if (localStream) {
@@ -1276,12 +1322,20 @@ const VideoChat = (() => {
       voiceAnimFrame = null;
     }
     if (audioContext) {
-      audioContext.close().catch(() => {});
+      try {
+        await audioContext.close();
+      } catch {
+        /* ignore close failures */
+      }
       audioContext = null;
     }
     stopAllRemoteSpeakingMonitors();
     if (speakingAudioContext) {
-      speakingAudioContext.close().catch(() => {});
+      try {
+        await speakingAudioContext.close();
+      } catch {
+        /* ignore close failures */
+      }
       speakingAudioContext = null;
     }
     localSpeakingUntil = 0;
@@ -1307,6 +1361,9 @@ const VideoChat = (() => {
     setStatusIcon("offline");
     updateStatus("fa-solid fa-power-off", "Disconnected", "muted");
     showToast("Session ended and media released", "success");
+    if (navigateHome) {
+      navigateToHome();
+    }
   }
 
   /* ── Voice changer ── */
@@ -1786,7 +1843,27 @@ const VideoChat = (() => {
     await initPeer();
     checkInitialPermissions();
     window.addEventListener("beforeunload", () => {
-      hangup();
+      // Inline synchronous teardown for unload – browsers don't wait for Promises
+      try {
+        if (peer) {
+          peer.disconnect();
+          peer.destroy();
+        }
+      } catch {
+        /* ignore sync disconnect/destroy failures */
+      }
+      if (localStream) {
+        localStream.getTracks().forEach((t) => t.stop());
+      }
+      if (typeof VoiceChanger !== "undefined") {
+        try {
+          VoiceChanger.destroy();
+        } catch {
+          /* ignore VoiceChanger destroy failures */
+        }
+      }
+      // Fire-and-forget: schedule full async cleanup without waiting
+      Promise.resolve().then(() => hangup({ navigateHome: false })).catch(() => {});
     });
     return true;
   }

--- a/public/js/video.js
+++ b/public/js/video.js
@@ -1323,6 +1323,9 @@ const VideoChat = (() => {
       }
     });
     activeDataConns.clear();
+    // Yield to allow any microtasks/event handlers triggered by close() to run while
+    // isEndingCall is still true and connections are known to be closing.
+    await Promise.resolve();
     lastProfileBroadcastAt.clear();
     peerProfiles.clear();
     stopAllRemoteSpeakingMonitors();
@@ -1982,8 +1985,14 @@ const VideoChat = (() => {
           /* ignore VoiceChanger destroy failures */
         }
       }
-      // Fire-and-forget: schedule full async cleanup without waiting
-      Promise.resolve().then(() => hangup({ navigateHome: false })).catch(() => {});
+      }
+    });
+
+    // pagehide is more reliable than beforeunload for cleanup across mobile and desktop.
+    window.addEventListener("pagehide", (event) => {
+      if (!event.persisted) {
+        hangup({ navigateHome: false }).catch(() => {});
+      }
     });
     return true;
   }

--- a/tests/test_video_chat.py
+++ b/tests/test_video_chat.py
@@ -460,7 +460,7 @@ def test_three_clients_connect_and_see_cameras(app_server_url):
             p2 = ctx2.new_page()
             p3 = ctx3.new_page()
 
-            video_url = f"{app_server_url}/video-room"
+            video_url = f"{app_server_url}/video-room?mic=on&cam=on"
             for page in (p1, p2, p3):
                 page.goto(video_url)
 
@@ -634,7 +634,7 @@ def voice_changer_page(app_server_url):
         try:
             ctx = _new_context(browser)
             page = ctx.new_page()
-            page.goto(f"{app_server_url}/video-room")
+            page.goto(f"{app_server_url}/video-room?mic=on&cam=on")
             # Wait for VoiceChanger to be defined (scripts loaded)
             page.wait_for_function("typeof VoiceChanger !== 'undefined'", timeout=TIMEOUT_MS)
             yield page

--- a/tests/test_video_chat.py
+++ b/tests/test_video_chat.py
@@ -323,7 +323,7 @@ def _patch_video_chat_html(data: bytes, peerjs_port: int) -> bytes:
     return html.encode("utf-8")
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="session")
 def peerjs_server():
     """Start a local PeerJS signaling server and yield its port number.
 
@@ -374,7 +374,7 @@ def peerjs_server():
             proc.kill()
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="session")
 def base_url(peerjs_server):
     """Start a local HTTP server and return its base URL."""
     if not _PEERJS_MIN_JS.exists():


### PR DESCRIPTION
## Summary
Fixes broken end-call behavior by guaranteeing complete teardown and clear navigation back to home. This prevents users from getting stuck in a dead-end in-call state after local hangup or remote disconnect.

## Changes
- Hardened teardown order to close active calls and data connections safely.
- Added deterministic return-home navigation after hangup cleanup completes.
- Kept end-call control visible when the last remote participant disconnects, so users always have a safe exit path.
- Added defensive error handling around connection and media cleanup paths.
- Updated E2E fixture scope alignment in tests to remove pre-existing pytest scope mismatch and keep CI test runs stable.

## Testing
- Ran full test suite locally with verbose output.
- Result: 18 passed, 0 failed.
- Verified local and remote call-end flows produce a reliable return path.

Before- 
<video src="https://github.com/user-attachments/assets/040d3980-64ae-4823-9d0c-6cecb9d62a6e" controls width="600"></video>

After- 
<video src="https://github.com/user-attachments/assets/1ef3e1eb-801f-49da-b6f7-bab669d4a573" controls width="600"></video>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * End-call flow now supports safer teardown options (keeps end-button visible and optionally skips immediate navigation home).
  * Navigation to home is de-duplicated to avoid multiple redirects.

* **Bug Fixes**
  * Suppresses transient "call ended/offline" UI during local teardown and improves error-tolerant cleanup of media/connections.
  * before-unload now performs synchronous cleanup and triggers async hangup reliably.

* **Tests**
  * Test servers now persist for the full test session to reduce setup/teardown flakiness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->