### PR TITLE
fix(video): auto-join valid invite room links

### DIFF
--- a/public/js/video-lobby.js
+++ b/public/js/video-lobby.js
@@ -659,6 +659,7 @@
     const displayNameInput = getDisplayNameInput();
     const micBtn = $("btn-preview-mic");
     const camBtn = $("btn-preview-cam");
+    let shouldAutoJoinFromInvite = false;
 
     bindPreviewVoiceControls();
     restoreDisplayNameFromStorage();
@@ -687,6 +688,7 @@
       if (sharedRoomId) {
         roomInput.value = sharedRoomId;
         if (isValidRoomId(sharedRoomId)) {
+          shouldAutoJoinFromInvite = true;
           showToast("Room ID loaded from share link", "info");
         }
       }
@@ -712,6 +714,13 @@
     if (camBtn) camBtn.addEventListener("click", toggleCamPreview);
 
     await initPreviewStream();
+
+    if (shouldAutoJoinFromInvite) {
+      const existingName = normalizeDisplayName(displayNameInput ? displayNameInput.value : "");
+      if (existingName) {
+        joinRoom();
+      }
+    }
   });
 
   window.addEventListener("beforeunload", stopPreviewStream);

--- a/public/js/video.js
+++ b/public/js/video.js
@@ -1040,7 +1040,7 @@ const VideoChat = (() => {
   function isValidRoomId(roomId) {
     if (!roomId || typeof roomId !== "string") return false;
     // Match the same character set used by Crypto.randomId(): uppercase A-Z (except I,O) + digits 2-9
-    return /^[ABCDEFGHJKLMNPQRSTUVWXYZ23456789]{6}$/.test(normalizeRoomId(roomId));
+    return /^[ABCDEFGHJKLMNPQRSTUVWXYZ23456789]{6}$/.test(roomId);
   }
 
   async function autoJoinFromInvite(roomId) {

--- a/public/js/video.js
+++ b/public/js/video.js
@@ -16,6 +16,8 @@ const VideoChat = (() => {
   let camOff = true;
   let consentGiven = false;
   let screenSharing = false;
+  let inviteAutoJoinAttempted = false;
+  let inviteAutoJoinRoomId = "";
   let initialMediaPreferences = { mic: true, cam: true };
   const VOICE_PREFS_STORAGE_KEY = "blt-safecloak-voice-preferences";
   const DISPLAY_NAME_STORAGE_KEY = "blt-safecloak-display-name";
@@ -126,6 +128,22 @@ const VideoChat = (() => {
   function getDisplayLabel(peerId) {
     if (peerId === state.peerId || peerId === "local") return "You";
     return getProfileForPeer(peerId).name || peerId;
+  }
+
+  function normalizeRoomId(value) {
+    return (value || "").trim().toUpperCase();
+  }
+
+  function getInviteRoomIdFromUrl() {
+    const params = new URLSearchParams(window.location.search);
+    return normalizeRoomId(params.get("room"));
+  }
+
+  function populateRemoteIdInput(roomId) {
+    const remoteInput = $("remote-id");
+    if (remoteInput) {
+      remoteInput.value = roomId;
+    }
   }
 
   function getSelfProfilePayload() {
@@ -762,16 +780,20 @@ const VideoChat = (() => {
       setStatusIcon("online");
       updateLocalTilePresentation();
       showToast("Connected to signaling server", "success");
-      // Populate room ID if passed in URL, but wait for user to click "Add Participant"
-      const params = new URLSearchParams(window.location.search);
-      const joinId = params.get("room");
-      if (joinId && joinId !== state.peerId) {
-        const remoteInput = $("remote-id");
-        if (remoteInput) {
-          remoteInput.value = joinId;
-        }
-        showToast("Room ID loaded from link — click Add Participant to join", "info");
+      const inviteRoomId = inviteAutoJoinRoomId || getInviteRoomIdFromUrl();
+      if (!inviteRoomId) {
+        return;
       }
+
+      if (!isValidRoomId(inviteRoomId)) {
+        showToast("Invite link contains an invalid Room ID", "warning");
+        return;
+      }
+
+      populateRemoteIdInput(inviteRoomId);
+      void autoJoinFromInvite(inviteRoomId).catch(() => {
+        showToast("Unable to auto-join from invite link", "error");
+      });
     });
 
     peer.on("call", async (incomingCall) => {
@@ -1018,7 +1040,42 @@ const VideoChat = (() => {
   function isValidRoomId(roomId) {
     if (!roomId || typeof roomId !== "string") return false;
     // Match the same character set used by Crypto.randomId(): uppercase A-Z (except I,O) + digits 2-9
-    return /^[ABCDEFGHJKLMNPQRSTUVWXYZ23456789]{6}$/.test(roomId.trim());
+    return /^[ABCDEFGHJKLMNPQRSTUVWXYZ23456789]{6}$/.test(normalizeRoomId(roomId));
+  }
+
+  async function autoJoinFromInvite(roomId) {
+    const normalizedRoomId = normalizeRoomId(roomId);
+    if (!normalizedRoomId || !isValidRoomId(normalizedRoomId)) {
+      return false;
+    }
+
+    populateRemoteIdInput(normalizedRoomId);
+
+    if (!peer || !state.peerId) {
+      inviteAutoJoinRoomId = normalizedRoomId;
+      return false;
+    }
+
+    if (normalizedRoomId === state.peerId) {
+      showToast("Invite link points to your own Room ID", "warning");
+      return false;
+    }
+
+    if (activeCalls.has(normalizedRoomId)) {
+      inviteAutoJoinAttempted = true;
+      inviteAutoJoinRoomId = normalizedRoomId;
+      return true;
+    }
+
+    if (inviteAutoJoinAttempted && inviteAutoJoinRoomId === normalizedRoomId) {
+      return false;
+    }
+
+    inviteAutoJoinAttempted = true;
+    inviteAutoJoinRoomId = normalizedRoomId;
+    showToast("Joining room from invite link...", "info");
+    await callPeer(normalizedRoomId);
+    return true;
   }
 
   async function callPeer(remotePeerId) {
@@ -1037,8 +1094,8 @@ const VideoChat = (() => {
       return;
     }
 
-    // Normalize the peer ID by trimming whitespace
-    remotePeerId = remotePeerId.trim();
+    // Normalize the peer ID to avoid whitespace/case mismatches
+    remotePeerId = normalizeRoomId(remotePeerId);
 
     if (!isValidRoomId(remotePeerId)) {
       showToast(
@@ -1794,6 +1851,7 @@ const VideoChat = (() => {
   return {
     init,
     callPeer,
+    autoJoinFromInvite,
     disconnectPeer,
     toggleMic,
     toggleCamera,

--- a/src/pages/video-room.html
+++ b/src/pages/video-room.html
@@ -520,16 +520,6 @@
           }, 5000);
         }
 
-        if (ok && isJoiner) {
-          try {
-            await VideoChat.autoJoinFromInvite(inviteRoomId);
-          } catch {
-            if (typeof showToast === "function") {
-              showToast("Unable to auto-join from invite link", "error");
-            }
-          }
-        }
-
         const callBtn = document.getElementById("btn-call");
         const input = document.getElementById("remote-id");
         if (callBtn && input) {

--- a/src/pages/video-room.html
+++ b/src/pages/video-room.html
@@ -502,8 +502,11 @@
     <script src="js/video.js"></script>
     <script>
       document.addEventListener("DOMContentLoaded", async () => {
+        const roomIdRe = /^[ABCDEFGHJKLMNPQRSTUVWXYZ23456789]{6}$/;
+        const normalizeRemoteId = (value) => (value || "").trim().toUpperCase();
         const params = new URLSearchParams(window.location.search);
-        const isJoiner = Boolean((params.get("room") || "").trim());
+        const inviteRoomId = normalizeRemoteId(params.get("room"));
+        const isJoiner = roomIdRe.test(inviteRoomId);
         const addParticipantCard = document.getElementById("add-participant-card");
         if (isJoiner && addParticipantCard) {
           addParticipantCard.style.display = "none";
@@ -517,18 +520,27 @@
           }, 5000);
         }
 
+        if (ok && isJoiner) {
+          try {
+            await VideoChat.autoJoinFromInvite(inviteRoomId);
+          } catch {
+            if (typeof showToast === "function") {
+              showToast("Unable to auto-join from invite link", "error");
+            }
+          }
+        }
+
         const callBtn = document.getElementById("btn-call");
         const input = document.getElementById("remote-id");
-        const normalizeRemoteId = (value) => value.trim().toUpperCase();
         if (callBtn && input) {
-          callBtn.addEventListener("click", () => {
-            VideoChat.callPeer(normalizeRemoteId(input.value));
+          callBtn.addEventListener("click", async () => {
+            await VideoChat.callPeer(normalizeRemoteId(input.value));
             input.value = "";
           });
 
-          input.addEventListener("keydown", (event) => {
+          input.addEventListener("keydown", async (event) => {
             if (event.key === "Enter") {
-              VideoChat.callPeer(normalizeRemoteId(event.target.value));
+              await VideoChat.callPeer(normalizeRemoteId(event.target.value));
               event.target.value = "";
             }
           });


### PR DESCRIPTION
### Summary
Restores deep-link behavior so valid invite links auto-join rooms after readiness and consent checks, removing the manual Add Participant step.

### Changes
- Added room-param normalization and validation before auto-join.
- Added guarded auto-call flow (prevents self-call and duplicate attempts).
- Triggered auto-join for joiners after room init.
- Added optional lobby auto-continue when invite room and display name are already present.

### Testing
- Verified baseline tests on synced main and post-fix tests show the same pre-existing fixture ScopeMismatch issue.
- Manual verification completed for invite-link auto-join and invalid room-param safe handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic joining from shared room invites—users with a valid invite link and a non-empty display name are now auto-joined after preview initializes.
  * Invite links now auto-populate the room input when present.

* **Bug Fixes / Improvements**
  * Stricter invite validation to prevent invalid or self-invite attempts.
  * Avoids repeated auto-join retries and surfaces errors via toast messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->