### PR TITLE
fix(video): enforce manual-only mic/camera activation at room start

### DIFF
--- a/public/js/video-lobby.js
+++ b/public/js/video-lobby.js
@@ -7,6 +7,7 @@
   const ROOM_ID_RE = /^[ABCDEFGHJKLMNPQRSTUVWXYZ23456789]{6}$/;
   const VOICE_PREFS_STORAGE_KEY = "blt-safecloak-voice-preferences";
   const DISPLAY_NAME_STORAGE_KEY = "blt-safecloak-display-name";
+  const MEDIA_PREFS_STORAGE_KEY = "blt-safecloak-media-preferences";
   const LOBBY_EFFECT_ORDER = ["deep", "chipmunk", "robot", "echo", "voice1", "voice2", "voice3"];
 
   let previewStream = null;
@@ -591,6 +592,20 @@
     return target;
   }
 
+  function persistMediaPreferences() {
+    const micPref = hasAudioTrack() ? micEnabled : false;
+    const camPref = hasVideoTrack() ? camEnabled : false;
+
+    try {
+      window.sessionStorage.setItem(
+        MEDIA_PREFS_STORAGE_KEY,
+        JSON.stringify({ mic: micPref, cam: camPref })
+      );
+    } catch {
+      /* ignore storage failures */
+    }
+  }
+
   function goToRoom(roomId = "", displayName = "") {
     if (displayName) {
       try {
@@ -600,6 +615,7 @@
       }
     }
     persistVoicePreferences();
+    persistMediaPreferences();
     const target = buildRoomUrl(roomId);
     stopPreviewStream();
     window.location.href = target.toString();

--- a/public/js/video-lobby.js
+++ b/public/js/video-lobby.js
@@ -11,8 +11,8 @@
   const LOBBY_EFFECT_ORDER = ["deep", "chipmunk", "robot", "echo", "voice1", "voice2", "voice3"];
 
   let previewStream = null;
-  let micEnabled = true;
-  let camEnabled = true;
+  let micEnabled = false;
+  let camEnabled = false;
   let voiceUiBound = false;
 
   const $ = (id) => document.getElementById(id);
@@ -560,8 +560,10 @@
     for (const mediaConstraints of constraints) {
       try {
         previewStream = await navigator.mediaDevices.getUserMedia(mediaConstraints);
-        micEnabled = hasAudioTrack();
-        camEnabled = hasVideoTrack();
+        micEnabled = false;
+        camEnabled = false;
+        setTrackEnabled("audio", false);
+        setTrackEnabled("video", false);
         updatePreviewUI();
         initPreviewVoiceEngine();
         return;

--- a/public/js/video.js
+++ b/public/js/video.js
@@ -17,6 +17,7 @@ const VideoChat = (() => {
   let consentGiven = false;
   let screenSharing = false;
   let initialMediaPreferences = { mic: true, cam: true };
+  const MEDIA_PREFS_STORAGE_KEY = "blt-safecloak-media-preferences";
   const VOICE_PREFS_STORAGE_KEY = "blt-safecloak-voice-preferences";
   const DISPLAY_NAME_STORAGE_KEY = "blt-safecloak-display-name";
   const PROFILE_BROADCAST_THROTTLE_MS = 220;
@@ -603,13 +604,17 @@ const VideoChat = (() => {
   }
 
   function applyInitialMediaPreferences() {
-    if (!localStream) return;
+    micMuted = !initialMediaPreferences.mic;
+    camOff = !initialMediaPreferences.cam;
+
+    if (!localStream) {
+      syncControlButtons();
+      updateLocalTilePresentation();
+      return;
+    }
 
     const hasAudioTrack = localStream.getAudioTracks().length > 0;
     const hasVideoTrack = localStream.getVideoTracks().length > 0;
-
-    micMuted = hasAudioTrack ? !initialMediaPreferences.mic : false;
-    camOff = hasVideoTrack ? !initialMediaPreferences.cam : false;
 
     if (hasAudioTrack) {
       localStream.getAudioTracks().forEach((track) => (track.enabled = !micMuted));
@@ -1061,10 +1066,6 @@ const VideoChat = (() => {
       if (!ok) return;
     }
 
-    micMuted = false;
-    camOff = false;
-    updateMediaButtons();
-
     const ok = await startLocalMedia();
     if (!ok) return;
 
@@ -1110,6 +1111,7 @@ const VideoChat = (() => {
         : '<i class="fa-solid fa-microphone" aria-hidden="true"></i>';
       micBtn.title = micMuted ? "Unmute mic" : "Mute mic";
       micBtn.classList.toggle("active", micMuted);
+      micBtn.setAttribute("aria-pressed", micMuted ? "true" : "false");
     }
     const camBtn = $("btn-cam");
     if (camBtn) {
@@ -1118,6 +1120,7 @@ const VideoChat = (() => {
         : '<i class="fa-solid fa-video" aria-hidden="true"></i>';
       camBtn.title = camOff ? "Enable camera" : "Disable camera";
       camBtn.classList.toggle("active", camOff);
+      camBtn.setAttribute("aria-pressed", camOff ? "true" : "false");
     }
   }
 
@@ -1749,15 +1752,51 @@ const VideoChat = (() => {
     const params = new URLSearchParams(window.location.search);
     const mic = params.get("mic");
     const cam = params.get("cam");
+    const isPrejoin = params.get("prejoin") === "1";
+
+    let parsedFromUrl = false;
 
     if (mic === "off" || mic === "on") {
       initialMediaPreferences.mic = mic === "on";
+      parsedFromUrl = true;
     }
     if (cam === "off" || cam === "on") {
       initialMediaPreferences.cam = cam === "on";
+      parsedFromUrl = true;
     }
 
-    if (params.get("prejoin") === "1") {
+    if (!parsedFromUrl) {
+      try {
+        const raw = window.sessionStorage.getItem(MEDIA_PREFS_STORAGE_KEY);
+        if (raw) {
+          const parsed = JSON.parse(raw);
+          if (parsed && typeof parsed === "object") {
+            if (typeof parsed.mic === "boolean") {
+              initialMediaPreferences.mic = parsed.mic;
+            }
+            if (typeof parsed.cam === "boolean") {
+              initialMediaPreferences.cam = parsed.cam;
+            }
+          }
+        }
+      } catch {
+        /* ignore storage failures */
+      }
+    }
+
+    try {
+      window.sessionStorage.setItem(
+        MEDIA_PREFS_STORAGE_KEY,
+        JSON.stringify({
+          mic: Boolean(initialMediaPreferences.mic),
+          cam: Boolean(initialMediaPreferences.cam),
+        })
+      );
+    } catch {
+      /* ignore storage failures */
+    }
+
+    if (isPrejoin) {
       params.delete("prejoin");
       params.delete("mic");
       params.delete("cam");
@@ -1773,11 +1812,13 @@ const VideoChat = (() => {
     state.displayInitials = makeInitials(state.displayName);
 
     readInitialMediaPreferencesFromUrl();
+    applyInitialMediaPreferences();
     updateLocalTilePresentation();
     
     // We try to start media immediately if we have preferences from the lobby
     const ok = await startLocalMedia();
     if (ok) {
+      applyInitialMediaPreferences();
       updateLocalTilePresentation();
       _applyStoredVoicePreferences();
     }

--- a/public/js/video.js
+++ b/public/js/video.js
@@ -16,7 +16,7 @@ const VideoChat = (() => {
   let camOff = true;
   let consentGiven = false;
   let screenSharing = false;
-  let initialMediaPreferences = { mic: true, cam: true };
+  let initialMediaPreferences = { mic: false, cam: false };
   const MEDIA_PREFS_STORAGE_KEY = "blt-safecloak-media-preferences";
   const VOICE_PREFS_STORAGE_KEY = "blt-safecloak-voice-preferences";
   const DISPLAY_NAME_STORAGE_KEY = "blt-safecloak-display-name";
@@ -1754,34 +1754,11 @@ const VideoChat = (() => {
     const cam = params.get("cam");
     const isPrejoin = params.get("prejoin") === "1";
 
-    let parsedFromUrl = false;
-
     if (mic === "off" || mic === "on") {
       initialMediaPreferences.mic = mic === "on";
-      parsedFromUrl = true;
     }
     if (cam === "off" || cam === "on") {
       initialMediaPreferences.cam = cam === "on";
-      parsedFromUrl = true;
-    }
-
-    if (!parsedFromUrl) {
-      try {
-        const raw = window.sessionStorage.getItem(MEDIA_PREFS_STORAGE_KEY);
-        if (raw) {
-          const parsed = JSON.parse(raw);
-          if (parsed && typeof parsed === "object") {
-            if (typeof parsed.mic === "boolean") {
-              initialMediaPreferences.mic = parsed.mic;
-            }
-            if (typeof parsed.cam === "boolean") {
-              initialMediaPreferences.cam = parsed.cam;
-            }
-          }
-        }
-      } catch {
-        /* ignore storage failures */
-      }
     }
 
     try {

--- a/public/js/video.js
+++ b/public/js/video.js
@@ -568,9 +568,9 @@ const VideoChat = (() => {
     if (micBtn) {
       if (!hasAudioTrack) {
         micBtn.innerHTML = '<i class="fa-solid fa-microphone-slash" aria-hidden="true"></i>';
-        micBtn.title = "Microphone not available";
-        micBtn.disabled = true;
-        micBtn.classList.add("opacity-50", "cursor-not-allowed");
+        micBtn.title = micMuted ? "Unmute mic" : "Mute mic";
+        micBtn.disabled = false;
+        micBtn.classList.remove("opacity-50", "cursor-not-allowed");
       } else {
         micBtn.innerHTML = micMuted
           ? '<i class="fa-solid fa-microphone-slash" aria-hidden="true"></i>'
@@ -587,9 +587,9 @@ const VideoChat = (() => {
     if (camBtn) {
       if (!hasVideoTrack) {
         camBtn.innerHTML = '<i class="fa-solid fa-video-slash" aria-hidden="true"></i>';
-        camBtn.title = "Camera not available";
-        camBtn.disabled = true;
-        camBtn.classList.add("opacity-50", "cursor-not-allowed");
+        camBtn.title = camOff ? "Enable camera" : "Disable camera";
+        camBtn.disabled = false;
+        camBtn.classList.remove("opacity-50", "cursor-not-allowed");
       } else {
         camBtn.innerHTML = camOff
           ? '<i class="fa-solid fa-video-slash" aria-hidden="true"></i>'
@@ -1753,6 +1753,7 @@ const VideoChat = (() => {
     const mic = params.get("mic");
     const cam = params.get("cam");
     const isPrejoin = params.get("prejoin") === "1";
+    const hasUrlPrefs = mic !== null || cam !== null;
 
     if (mic === "off" || mic === "on") {
       initialMediaPreferences.mic = mic === "on";
@@ -1761,16 +1762,35 @@ const VideoChat = (() => {
       initialMediaPreferences.cam = cam === "on";
     }
 
-    try {
-      window.sessionStorage.setItem(
-        MEDIA_PREFS_STORAGE_KEY,
-        JSON.stringify({
-          mic: Boolean(initialMediaPreferences.mic),
-          cam: Boolean(initialMediaPreferences.cam),
-        })
-      );
-    } catch {
-      /* ignore storage failures */
+    if (hasUrlPrefs) {
+      try {
+        window.sessionStorage.setItem(
+          MEDIA_PREFS_STORAGE_KEY,
+          JSON.stringify({
+            mic: Boolean(initialMediaPreferences.mic),
+            cam: Boolean(initialMediaPreferences.cam),
+          })
+        );
+      } catch {
+        /* ignore storage failures */
+      }
+    } else {
+      try {
+        const raw = window.sessionStorage.getItem(MEDIA_PREFS_STORAGE_KEY);
+        if (raw) {
+          const parsed = JSON.parse(raw);
+          if (parsed && typeof parsed === "object") {
+            if (typeof parsed.mic === "boolean") {
+              initialMediaPreferences.mic = parsed.mic;
+            }
+            if (typeof parsed.cam === "boolean") {
+              initialMediaPreferences.cam = parsed.cam;
+            }
+          }
+        }
+      } catch {
+        /* ignore storage failures */
+      }
     }
 
     if (isPrejoin) {
@@ -1792,13 +1812,16 @@ const VideoChat = (() => {
     applyInitialMediaPreferences();
     updateLocalTilePresentation();
     
-    // We try to start media immediately if we have preferences from the lobby
-    const ok = await startLocalMedia();
-    if (ok) {
-      applyInitialMediaPreferences();
-      updateLocalTilePresentation();
-      _applyStoredVoicePreferences();
+    // Start media eagerly only when the initial preference explicitly enables mic/camera.
+    if (initialMediaPreferences.mic || initialMediaPreferences.cam) {
+      const ok = await startLocalMedia();
+      if (ok) {
+        applyInitialMediaPreferences();
+        updateLocalTilePresentation();
+      }
     }
+
+    _applyStoredVoicePreferences();
     
     // Always init peer regardless of success of startLocalMedia (can join without media)
     await initPeer();

--- a/src/pages/video-room.html
+++ b/src/pages/video-room.html
@@ -432,20 +432,22 @@
           <button
             class="control-btn rounded-full border border-neutral-border bg-white text-gray-700"
             id="btn-mic"
-            title="Mute mic"
+            title="Unmute mic"
             onclick="VideoChat.toggleMic()"
             aria-label="Toggle microphone"
+            aria-pressed="true"
           >
-            <i class="fa-solid fa-microphone" aria-hidden="true"></i>
+            <i class="fa-solid fa-microphone-slash" aria-hidden="true"></i>
           </button>
           <button
             class="control-btn rounded-full border border-neutral-border bg-white text-gray-700"
             id="btn-cam"
-            title="Disable camera"
+            title="Enable camera"
             onclick="VideoChat.toggleCamera()"
             aria-label="Toggle camera"
+            aria-pressed="true"
           >
-            <i class="fa-solid fa-video" aria-hidden="true"></i>
+            <i class="fa-solid fa-video-slash" aria-hidden="true"></i>
           </button>
           <button
             class="control-btn rounded-full border border-neutral-border bg-white text-gray-700"


### PR DESCRIPTION
## Summary
Ensures privacy-first media behavior in video chat by keeping microphone and camera disabled at room creation and page load until the user explicitly enables them.

## What Changed
- Removed startup paths that could implicitly re-enable mic/camera during call initialization.
- Standardized room defaults to muted mic and camera-off on first render and on reload.
- Updated lobby prejoin flow so initial preview and room handoff preserve off-by-default behavior.
- Kept control button icons and `aria-pressed` states aligned with actual media track state.

## Testing
- Verified local dev flow on room creation: mic/camera remain off by default.
- Verified reload behavior: no auto-unmute/auto-enable occurs.
- Verified user can manually enable mic/camera via controls.
- Ran project tests locally.

<video src="https://github.com/user-attachments/assets/4cbe16fb-6ccc-47b3-92e3-c0f748154cae" controls width="600"></video>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Media preferences (microphone and camera settings) are now persisted within your session, preserving your choices as you navigate between rooms.

* **Improvements**
  * Default microphone and camera state changed to disabled on initial load.
  * Enhanced accessibility with improved button state indicators and tooltips.
  * Updated UI icons to accurately reflect device enable/disable states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->