### PR TITLE
Add error handling for unhandled exceptions in worker entrypoint

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -23,18 +23,24 @@ class Default(WorkerEntrypoint):
         url = urlparse(request.url)
         path = url.path
 
-        # Handle CORS preflight
-        if request.method == 'OPTIONS':
-            return cors_response()
+        try:
+            # Handle CORS preflight
+            if request.method == 'OPTIONS':
+                return cors_response()
 
-        # Handle GET requests for HTML pages
-        if request.method == 'GET' and path in PAGES_MAP:
-            html_path = Path(__file__).parent / 'pages' / PAGES_MAP[path]
-            html_content = html_path.read_text(encoding='utf-8')
-            return html_response(html_content)
+            # Handle GET requests for HTML pages
+            if request.method == 'GET' and path in PAGES_MAP:
+                html_path = Path(__file__).parent / 'pages' / PAGES_MAP[path]
+                html_content = html_path.read_text(encoding='utf-8')
+                return html_response(html_content)
 
-        # Serving static files from the 'public' directory
-        if hasattr(env, 'ASSETS'):
-            return await env.ASSETS.fetch(request)
+            # Serving static files from the 'public' directory
+            if hasattr(env, 'ASSETS'):
+                return await env.ASSETS.fetch(request)
 
-        return Response('Not Found', status=404)
+            return Response('Not Found', status=404)
+
+        except FileNotFoundError:
+            return Response('Not Found', status=404)
+        except Exception:
+            return Response('Internal Server Error', status=500)

--- a/src/main.py
+++ b/src/main.py
@@ -40,7 +40,9 @@ class Default(WorkerEntrypoint):
 
             return Response('Not Found', status=404)
 
-        except FileNotFoundError:
+        except FileNotFoundError as exc:
+            print(f'[404] Page file not found: {exc}')
             return Response('Not Found', status=404)
-        except Exception:
+        except Exception as exc:
+            print(f'[500] Unexpected error: {exc}')
             return Response('Internal Server Error', status=500)

--- a/src/main.py
+++ b/src/main.py
@@ -1,9 +1,12 @@
 # pylint: disable=too-few-public-methods
+import asyncio
+import traceback
+
 from workers import WorkerEntrypoint, Response
 from urllib.parse import urlparse
 from pathlib import Path
 
-from libs.utils import html_response, cors_response
+from libs.utils import html_response, cors_response, base_headers
 
 # Route to HTML page mapping
 PAGES_MAP = {
@@ -42,7 +45,17 @@ class Default(WorkerEntrypoint):
 
         except FileNotFoundError as exc:
             print(f'[404] Page file not found: {exc}')
-            return Response('Not Found', status=404)
+            return Response(
+                'Not Found',
+                status=404,
+                headers=base_headers('text/plain; charset=utf-8')
+            )
+        except asyncio.CancelledError:
+            raise
         except Exception as exc:
-            print(f'[500] Unexpected error: {exc}')
-            return Response('Internal Server Error', status=500)
+            traceback.print_exc()
+            return Response(
+                'Internal Server Error',
+                status=500,
+                headers=base_headers('text/plain; charset=utf-8')
+            )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,8 +3,9 @@ import os
 import json
 import pytest
 import ast
+import asyncio
 from datetime import datetime
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch, AsyncMock
 
 # --- THE CLOUDFLARE MOCK ---
 # This creates a "fake" Cloudflare workers module so local Python doesn't crash.
@@ -17,6 +18,7 @@ class FakeResponse:
         self.headers = headers or {}
 
 mock_workers.Response = FakeResponse
+mock_workers.WorkerEntrypoint = type('WorkerEntrypoint', (), {})
 sys.modules['workers'] = mock_workers
 # ---------------------------
 
@@ -77,3 +79,87 @@ def test_json_response_default_str_fallback():
     assert response_data["timestamp"] == "2026-03-22 12:00:00"
     actual_set = set(ast.literal_eval(response_data["unique_items"]))
     assert actual_set == {1, 2, 3}
+
+
+# --- on_fetch error handling tests ---
+# main.py uses 'from libs.utils import ...' (Cloudflare Workers path),
+# so we register src/libs as 'libs' before importing main.
+import src.libs.utils as _utils_mod
+sys.modules['libs'] = type(sys)('libs')
+sys.modules['libs.utils'] = _utils_mod
+
+from src.main import Default
+
+
+def _make_request(method='GET', path='/'):
+    """Create a fake request object for testing."""
+    req = MagicMock()
+    req.method = method
+    req.url = f'http://localhost:8787{path}'
+    return req
+
+
+def _make_env(has_assets=False):
+    """Create a fake env object for testing."""
+    env = MagicMock(spec=[])
+    if has_assets:
+        env.ASSETS = AsyncMock()
+    return env
+
+
+def test_on_fetch_missing_page_returns_404():
+    """Verify that a missing page file returns a clean 404, not an unhandled exception."""
+    worker = Default()
+    req = _make_request('GET', '/consent')
+    env = _make_env()
+
+    with patch('src.main.Path') as mock_path:
+        mock_path.return_value = mock_path
+        mock_path.__truediv__ = MagicMock(return_value=mock_path)
+        instance = mock_path.return_value
+        instance.parent.__truediv__ = MagicMock(return_value=instance)
+        # Simulate read_text raising FileNotFoundError
+        instance.read_text.side_effect = FileNotFoundError('consent.html not found')
+
+        # Patch Path(__file__).parent / 'pages' / ... to raise
+        with patch.object(Default, 'on_fetch', wraps=worker.on_fetch):
+            response = asyncio.run(worker.on_fetch(req, env))
+
+    assert response.status_code == 404
+    assert b'Not Found' in response.body
+
+
+def test_on_fetch_unexpected_error_returns_500():
+    """Verify that an unexpected exception returns a clean 500, not a stack trace."""
+    worker = Default()
+    req = _make_request('GET', '/notes')
+    env = _make_env()
+
+    with patch('src.main.Path') as mock_path:
+        mock_instance = MagicMock()
+        mock_path.return_value = mock_instance
+        mock_instance.parent.__truediv__ = MagicMock(return_value=mock_instance)
+        mock_instance.__truediv__ = MagicMock(return_value=mock_instance)
+        mock_instance.read_text.side_effect = RuntimeError('disk I/O error')
+
+        response = asyncio.run(worker.on_fetch(req, env))
+
+    assert response.status_code == 500
+    assert b'Internal Server Error' in response.body
+
+
+def test_on_fetch_cancelled_error_is_reraised():
+    """Verify that asyncio.CancelledError is not swallowed by the error handler."""
+    worker = Default()
+    req = _make_request('GET', '/notes')
+    env = _make_env()
+
+    with patch('src.main.Path') as mock_path:
+        mock_instance = MagicMock()
+        mock_path.return_value = mock_instance
+        mock_instance.parent.__truediv__ = MagicMock(return_value=mock_instance)
+        mock_instance.__truediv__ = MagicMock(return_value=mock_instance)
+        mock_instance.read_text.side_effect = asyncio.CancelledError()
+
+        with pytest.raises(asyncio.CancelledError):
+            asyncio.run(worker.on_fetch(req, env))


### PR DESCRIPTION
Wraps the request handler in a try/except to prevent unhandled exceptions
(e.g. missing page files, permission errors) from returning raw 500 responses
with stack traces. Returns clean 404/500 status codes instead, avoiding
internal path leakage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for file requests and asset serving, ensuring the application returns appropriate error responses when content is unavailable or server issues occur, rather than unexpected failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->