### PR TITLE
fix(video): preserve Room ID input field on call failure

### DIFF
--- a/public/js/video.js
+++ b/public/js/video.js
@@ -1112,17 +1112,17 @@ const VideoChat = (() => {
   async function callPeer(remotePeerId) {
     if (!peer) {
       showToast("Not connected to server", "error");
-      return;
+      return false;
     }
     if (!remotePeerId) {
       showToast("Enter a Room ID to call", "warning");
-      return;
+      return false;
     }
 
     // Ensure remotePeerId is a string before trimming
     if (typeof remotePeerId !== "string") {
       showToast("Invalid Room ID format", "error");
-      return;
+      return false;
     }
 
     // Normalize the peer ID to avoid whitespace/case mismatches
@@ -1133,24 +1133,24 @@ const VideoChat = (() => {
         "Room ID must be exactly 6 characters using only uppercase letters (A-Z except I,O) and digits (2-9)",
         "error"
       );
-      return;
+      return false;
     }
     if (remotePeerId === state.peerId) {
       showToast("You cannot call yourself", "warning");
-      return;
+      return false;
     }
     if (activeCalls.has(remotePeerId)) {
       showToast("Already connected to this participant", "warning");
-      return;
+      return false;
     }
 
     if (!consentGiven) {
       const ok = await askConsent("the remote participant");
-      if (!ok) return;
+      if (!ok) return false;
     }
 
     const ok = await startLocalMedia();
-    if (!ok) return;
+    if (!ok) return false;
 
     updateStatus("fa-solid fa-spinner fa-spin", "Calling...", "warning");
     setStatusIcon("connecting");
@@ -1159,6 +1159,7 @@ const VideoChat = (() => {
     updateParticipantsList();
     handleCallStream(call);
     ensureDataConn(remotePeerId);
+    return true;
   }
 
   /* ── Controls ── */

--- a/src/pages/video-room.html
+++ b/src/pages/video-room.html
@@ -526,14 +526,18 @@
         const input = document.getElementById("remote-id");
         if (callBtn && input) {
           callBtn.addEventListener("click", async () => {
-            await VideoChat.callPeer(normalizeRemoteId(input.value));
-            input.value = "";
+            const success = await VideoChat.callPeer(normalizeRemoteId(input.value));
+            if (success) {
+              input.value = "";
+            }
           });
 
           input.addEventListener("keydown", async (event) => {
             if (event.key === "Enter") {
-              await VideoChat.callPeer(normalizeRemoteId(event.target.value));
-              event.target.value = "";
+              const success = await VideoChat.callPeer(normalizeRemoteId(event.target.value));
+              if (success) {
+                event.target.value = "";
+              }
             }
           });
         }


### PR DESCRIPTION
## Description
This PR addresses review feedback from CodeRabbit regarding the UI behavior during failed call attempts.

### Changes
- **Core (video.js)**: Modified `VideoChat.callPeer` to return a boolean indicating success. It now returns `false` for early exits (validation errors, calling self, consent denied, etc.) and `true` only when a call attempt successfully initiates.
- **UI (video-room.html)**: Updated the call initiation event listeners (Click and Enter key) to check the return value of `callPeer`. The input field is now only cleared if the call attempt was successful, allowing users to easily retry or correct errors in the Room ID.

### Verification
- **Automated**: Ran the full video chat E2E suite (`pytest tests/test_video_chat.py`). All 14 tests passed.
- **Manual**: Verified that entering an invalid ID or an aborted call attempt preserves the input text for the user.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * "Add Participant" input now only clears when a call is successfully initiated, preventing misleading UI behavior.
  * Call initiation now reports explicit success/failure so the UI can reliably reflect whether adding a participant worked.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->