### PR TITLE
fix(consent): Use Crypto.randomId() for consent entry IDs

### DIFF
--- a/public/js/consent.js
+++ b/public/js/consent.js
@@ -29,7 +29,7 @@ const ConsentManager = (() => {
   async function record(event) {
     const ts = Date.now();
     const entry = {
-      id: ts.toString() + Math.random().toString(36).slice(2, 7),
+      id: ts.toString() + Crypto.randomId(5),
       type: event.type || "recorded", // 'given' | 'withdrawn' | 'recorded'
       name: event.name || "Unnamed event",
       details: event.details || "",


### PR DESCRIPTION
Replace `Math.random().toString(36)` with the existing `Crypto.randomId()` 
utility for generating consent entry ID suffixes.

## Problem
Consent entry IDs use `Math.random()` which is not cryptographically secure, 
while the same module already uses `Crypto.sha256()` for tamper-evident hashing 
on the same entry. This is an inconsistency.

## Solution
Use `Crypto.randomId(5)` which calls `crypto.getRandomValues()` internally — 
the same CSPRNG backing the rest of the crypto utilities in this project.

## Testing
- [x] No lint or runtime errors
- [x] `Crypto.randomId()` is already loaded in consent.html via crypto.js
- [x]ID structure preserved (timestamp + random suffix). Suffix character set changes from base-36 to the project's standard Crypto.randomId set.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the consent event ID generation mechanism to use a more robust approach for internal logging entries. This change maintains all existing functionality with no impact to user-visible features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->