### PR TITLE
add peer reconnection with exponential backoff on disconnect

### DIFF
--- a/public/js/video.js
+++ b/public/js/video.js
@@ -36,6 +36,9 @@ const VideoChat = (() => {
   const lastProfileBroadcastAt = new Map(); // peerId -> timestamp
   let navigationInProgress = false;
   let isEndingCall = false;
+  let reconnectAttempts = 0;
+  const MAX_RECONNECT_ATTEMPTS = 3;
+  const RECONNECT_BASE_DELAY_MS = 1000;
 
   const state = {
     peerId: null,
@@ -884,6 +887,7 @@ const VideoChat = (() => {
     );
 
     peer.on("open", (id) => {
+      reconnectAttempts = 0;
       $("my-peer-id") && ($("my-peer-id").textContent = id);
       persistOwnRoomId(id);
       ensureRoomIdInUrl(id);
@@ -948,8 +952,27 @@ const VideoChat = (() => {
     });
 
     peer.on("disconnected", () => {
-      updateStatus("fa-solid fa-plug-circle-xmark", "Disconnected", "warning");
-      setStatusIcon("offline");
+      if (peer.destroyed || isEndingCall) {
+        updateStatus("fa-solid fa-plug-circle-xmark", "Disconnected", "warning");
+        setStatusIcon("offline");
+        return;
+      }
+      if (reconnectAttempts < MAX_RECONNECT_ATTEMPTS) {
+        reconnectAttempts++;
+        const delay = RECONNECT_BASE_DELAY_MS * Math.pow(2, reconnectAttempts - 1);
+        updateStatus("fa-solid fa-arrows-rotate fa-spin", `Reconnecting (${reconnectAttempts}/${MAX_RECONNECT_ATTEMPTS})…`, "warning");
+        setStatusIcon("offline");
+        const currentPeer = peer;
+        setTimeout(() => {
+          if (currentPeer === peer && !isEndingCall && !currentPeer.destroyed && !currentPeer.open) {
+            currentPeer.reconnect();
+          }
+        }, delay);
+      } else {
+        updateStatus("fa-solid fa-plug-circle-xmark", "Disconnected — could not reconnect", "danger");
+        setStatusIcon("offline");
+        showToast("Lost connection to signaling server. Please rejoin.", "error");
+      }
     });
   }
 


### PR DESCRIPTION
## Problem
When a participant loses connection to the PeerJS signaling server (e.g. brief WiFi drop, network switch, or laptop sleep), the current code only updates the status text to "Disconnected" and does nothing to recover. The user must manually refresh the page and rejoin the room.
This is especially impactful for the room creator — since the Room ID is their Peer ID, a disconnect means no new participants can join until they manually reconnect.
## Solution
Added automatic reconnection with exponential backoff to the `peer.on("disconnected")` handler:
- Attempts `peer.reconnect()` up to **3 times** with increasing delays (1s → 2s → 4s)
- Shows a spinning "Reconnecting (1/3)…" status so the user knows recovery is in progress
- Skips reconnect if the peer was intentionally destroyed or the user ended the call
- Resets the retry counter on successful reconnection (`peer.on("open")`)
- After all retries fail, shows an error toast asking the user to rejoin



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Implemented automatic reconnection attempts when the connection is lost, with up to 3 retry attempts using exponential backoff delays.
  * Added real-time status indicators during reconnection attempts, showing progress (e.g., "Reconnecting (2/3)…").
  * Displays a final "Disconnected — could not reconnect" message with error notification instructing the user to rejoin when maximum reconnection attempts are exceeded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->