### PR TITLE
fix: toggle screen share button to stop sharing on second click

### DIFF
--- a/public/js/video.js
+++ b/public/js/video.js
@@ -2091,6 +2091,13 @@ const VideoChat = (() => {
   }
 
   function stopScreenShare() {
+    // Always reset UI and state regardless of localStream
+    $("btn-screen") && $("btn-screen").classList.remove("active");
+    screenSharing = false;
+    updateLocalTilePresentation();
+    broadcastProfile(true);
+    showToast("Screen sharing stopped", "info");
+
     if (!localStream) return;
     const videoTrack = localStream.getVideoTracks()[0];
     if (videoTrack && activeCalls.size > 0) {
@@ -2117,12 +2124,16 @@ const VideoChat = (() => {
     if (localVideo) {
       localVideo.srcObject = localStream;
     }
-    $("btn-screen") && $("btn-screen").classList.remove("active");
-    screenSharing = false;
-    updateLocalTilePresentation();
-    broadcastProfile(true);
-    showToast("Screen sharing stopped", "info");
   }
+
+  /* Toggle screen share on/off */
+  function toggleScreenShare() {
+  if (screenSharing) {
+    stopScreenShare();
+  } else {
+    shareScreen();
+  }
+}
 
   function readInitialMediaPreferencesFromUrl() {
     const params = new URLSearchParams(window.location.search);
@@ -2253,6 +2264,7 @@ const VideoChat = (() => {
     toggleMonitor,
     shareScreen,
     stopScreenShare,
+    toggleScreenShare,
     copyRoomId,
     copyRoomLink,
     state,

--- a/public/js/video.js
+++ b/public/js/video.js
@@ -16,6 +16,7 @@ const VideoChat = (() => {
   let camOff = true;
   let consentGiven = false;
   let screenSharing = false;
+  let activeScreenStream = null;
   let localHandRaised = false;
   let inviteAutoJoinAttempted = false;
   let inviteAutoJoinRoomId = "";
@@ -2062,10 +2063,15 @@ const VideoChat = (() => {
     copyToClipboard(url, "Room link");
   }
 
-  /* ── Screen share ── */
+  /**
+   * Captures the user's screen and replaces the video track in all active peer calls.
+   * @async
+   * @returns {Promise<void>}
+   */
   async function shareScreen() {
     try {
       const screenStream = await navigator.mediaDevices.getDisplayMedia({ video: true });
+      activeScreenStream = screenStream;
       const screenTrack = screenStream.getVideoTracks()[0];
       for (const call of activeCalls.values()) {
         // Use cached sender reference (robust against null tracks)
@@ -2090,6 +2096,11 @@ const VideoChat = (() => {
     }
   }
 
+
+    /**
+   * Stops screen sharing, terminates the screen tracks, and restores the camera stream.
+   * @returns {void}
+   */
   function stopScreenShare() {
     // Always reset UI and state regardless of localStream
     $("btn-screen") && $("btn-screen").classList.remove("active");
@@ -2097,6 +2108,11 @@ const VideoChat = (() => {
     updateLocalTilePresentation();
     broadcastProfile(true);
     showToast("Screen sharing stopped", "info");
+
+    if (activeScreenStream) {
+      activeScreenStream.getTracks().forEach(track => track.stop());
+      activeScreenStream = null;
+    }
 
     if (!localStream) return;
     const videoTrack = localStream.getVideoTracks()[0];
@@ -2126,13 +2142,19 @@ const VideoChat = (() => {
     }
   }
 
-  /* Toggle screen share on/off */
+
+    /**
+   * Toggles between starting and stopping screen share based on current state.
+   * @returns {void}
+   */
   function toggleScreenShare() {
   if (screenSharing) {
     stopScreenShare();
   } else {
     shareScreen();
   }
+  const btn = $("btn-screen");
+  if (btn) btn.setAttribute("aria-pressed", screenSharing.toString());
 }
 
   function readInitialMediaPreferencesFromUrl() {

--- a/src/pages/video-room.html
+++ b/src/pages/video-room.html
@@ -471,7 +471,7 @@
             class="control-btn rounded-full border border-neutral-border bg-white text-gray-700"
             id="btn-screen"
             title="Share screen"
-            onclick="VideoChat.shareScreen()"
+            onclick="VideoChat.toggleScreenShare()"
             aria-label="Share screen"
           >
             <i class="fa-solid fa-display" aria-hidden="true"></i>

--- a/src/pages/video-room.html
+++ b/src/pages/video-room.html
@@ -473,6 +473,7 @@
             title="Share screen"
             onclick="VideoChat.toggleScreenShare()"
             aria-label="Share screen"
+            aria-pressed="false"
           >
             <i class="fa-solid fa-display" aria-hidden="true"></i>
           </button>


### PR DESCRIPTION
Resolves #96

**Changes**
- Added `toggleScreenShare()` function in `video.js` that checks 
  `screenSharing` state and calls either `shareScreen()` or 
  `stopScreenShare()` accordingly
- Updated `btn-screen` in `video-room.html` to call 
  `VideoChat.toggleScreenShare()` instead of `VideoChat.shareScreen()`
- Exposed `toggleScreenShare` in the public API return object
- Fixed `stopScreenShare()` to reset UI state and `screenSharing` flag 
  before the `localStream` check, ensuring the button always returns 
  to its inactive state even when no active call is present

**Testing**
- Tested locally and on Cloudflare deployment
- Screen share starts on first click 
- Screen share stops on second click 

https://github.com/user-attachments/assets/70462283-43ac-40e7-8b3b-bbf27d66cd5e



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Resolved screen sharing state reset issue to ensure the user interface properly updates when ending a screen share session, including disabling the active button state.

* **New Features**
  * Screen share control button now functions as a toggle, allowing users to start and stop screen sharing with a single click, automatically switching between the two states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->