### PR TITLE
feat(lobby): add individual mute button for participants

### DIFF
--- a/public/js/video-lobby.js
+++ b/public/js/video-lobby.js
@@ -788,4 +788,10 @@
   });
 
   window.addEventListener("beforeunload", stopPreviewStream);
+
+  window.toggleParticipantMute = function(peerId) {
+    if (typeof VideoChat !== "undefined" && VideoChat.togglePeerAudioMute) {
+      VideoChat.togglePeerAudioMute(peerId);
+    }
+  };
 })();

--- a/public/js/video-lobby.js
+++ b/public/js/video-lobby.js
@@ -788,10 +788,4 @@
   });
 
   window.addEventListener("beforeunload", stopPreviewStream);
-
-  window.toggleParticipantMute = function(peerId) {
-    if (typeof VideoChat !== "undefined" && VideoChat.togglePeerAudioMute) {
-      VideoChat.togglePeerAudioMute(peerId);
-    }
-  };
 })();

--- a/public/js/video.js
+++ b/public/js/video.js
@@ -30,6 +30,7 @@ const VideoChat = (() => {
 
   const peerProfiles = new Map(); // peerId -> { name, initials, micMuted, camOff, handRaised }
   const remoteSpeakingMonitors = new Map(); // peerId -> { analyser, data, source, activeUntil }
+  const mutedPeers = new Set(); // peerId -> locally muted audio
   let speakingLoopFrame = null;
   let speakingAudioContext = null;
   let localSpeakingUntil = 0;
@@ -290,6 +291,7 @@ const VideoChat = (() => {
     const videoEl = document.createElement("video");
     videoEl.autoplay = true;
     videoEl.playsInline = true;
+    videoEl.muted = mutedPeers.has(peerId);
     videoEl.setAttribute("aria-label", `Participant ${profile.name} video`);
     videoWrapper.appendChild(videoEl);
 
@@ -1061,6 +1063,21 @@ const VideoChat = (() => {
       textWrap.appendChild(idLabel);
       nameSpan.appendChild(textWrap);
 
+      const muteBtn = document.createElement("button");
+      const isMuted = mutedPeers.has(peerId);
+      muteBtn.className = "control-btn participant-mute-btn";
+      muteBtn.style.cssText = "width:32px;height:32px;font-size:0.75rem";
+      muteBtn.title = isMuted ? `Unmute ${getDisplayLabel(peerId)}` : `Mute ${getDisplayLabel(peerId)}`;
+      muteBtn.setAttribute("aria-label", muteBtn.title);
+      muteBtn.innerHTML = isMuted ? '<i class="fa-solid fa-microphone-slash" aria-hidden="true"></i>' : '<i class="fa-solid fa-microphone" aria-hidden="true"></i>';
+      muteBtn.addEventListener("click", () => {
+        if (typeof window.toggleParticipantMute === 'function') {
+          window.toggleParticipantMute(peerId);
+        } else {
+          VideoChat.togglePeerAudioMute(peerId);
+        }
+      });
+
       const disconnectBtn = document.createElement("button");
       disconnectBtn.className = "control-btn";
       disconnectBtn.style.cssText = "width:32px;height:32px;font-size:0.75rem";
@@ -1069,8 +1086,13 @@ const VideoChat = (() => {
       disconnectBtn.innerHTML = '<i class="fa-solid fa-phone-slash" aria-hidden="true"></i>';
       disconnectBtn.addEventListener("click", () => VideoChat.disconnectPeer(peerId));
 
+      const actionsSpan = document.createElement("span");
+      actionsSpan.className = "flex items-center gap-1.5";
+      actionsSpan.appendChild(muteBtn);
+      actionsSpan.appendChild(disconnectBtn);
+
       item.appendChild(nameSpan);
-      item.appendChild(disconnectBtn);
+      item.appendChild(actionsSpan);
       listEl.appendChild(item);
     });
   }
@@ -1516,6 +1538,21 @@ const VideoChat = (() => {
     if (call) {
       call.close();
     }
+  }
+
+  function togglePeerAudioMute(peerId) {
+    if (mutedPeers.has(peerId)) {
+      mutedPeers.delete(peerId);
+    } else {
+      mutedPeers.add(peerId);
+    }
+    
+    const tile = getTileElements(peerId);
+    if (tile && tile.video) {
+        tile.video.muted = mutedPeers.has(peerId);
+    }
+    
+    updateParticipantsList();
   }
 
   async function endCall(options = {}) {
@@ -2256,5 +2293,6 @@ const VideoChat = (() => {
     copyRoomId,
     copyRoomLink,
     state,
+    togglePeerAudioMute,
   };
 })();

--- a/public/js/video.js
+++ b/public/js/video.js
@@ -1069,12 +1069,13 @@ const VideoChat = (() => {
       muteBtn.style.cssText = "width:32px;height:32px;font-size:0.75rem";
       muteBtn.title = isMuted ? `Unmute ${getDisplayLabel(peerId)}` : `Mute ${getDisplayLabel(peerId)}`;
       muteBtn.setAttribute("aria-label", muteBtn.title);
+      muteBtn.setAttribute("aria-pressed", String(isMuted));
       muteBtn.innerHTML = isMuted ? '<i class="fa-solid fa-microphone-slash" aria-hidden="true"></i>' : '<i class="fa-solid fa-microphone" aria-hidden="true"></i>';
       muteBtn.addEventListener("click", () => {
-        if (typeof window.toggleParticipantMute === 'function') {
+        if (typeof window.toggleParticipantMute === "function") {
           window.toggleParticipantMute(peerId);
         } else {
-          VideoChat.togglePeerAudioMute(peerId);
+          togglePeerAudioMute(peerId);
         }
       });
 
@@ -2296,3 +2297,9 @@ const VideoChat = (() => {
     togglePeerAudioMute,
   };
 })();
+
+window.toggleParticipantMute = (peerId) => {
+  if (typeof VideoChat !== "undefined" && VideoChat.togglePeerAudioMute) {
+    VideoChat.togglePeerAudioMute(peerId);
+  }
+};

--- a/src/pages/video-room.html
+++ b/src/pages/video-room.html
@@ -416,6 +416,8 @@
                 >
               </h2>
               <div id="participants-list">
+                <!-- Participant list items are dynamically injected here. -->
+                <!-- Each item includes a mute button (for local muting) before the disconnect button. -->
                 <p class="py-2 text-center text-sm text-gray-500">No participants connected</p>
               </div>
             </div>


### PR DESCRIPTION
## Summary
Adds an individual mute button to the participant list to silence remote users locally. Includes accessibility improvements and fixes for script loading dependencies.

## Changes
- **Mute Logic**: Implemented local mute state tracking in `video.js`.
- **Global Hook**: Moved the mute handler to `video.js` to ensure availability in the video room.
- **Accessibility**: Added `aria-pressed` and dynamic title/label updates for screen readers.
- **UI**: Integrated mute icon toggle before the disconnect button.

## Testing
- Verified that muting only affects the local session.
- All existing tests passed via `pytest`.

<video src="https://github.com/user-attachments/assets/7eab4291-d960-457b-90b3-798dd9667d43" controls width="600"></video>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added individual participant mute controls in the participants list
  * Each remote participant now displays a mute button (microphone icon) next to their disconnect button for local audio muting
  * Mute state is correctly maintained when video tiles are created or refreshed

<!-- end of auto-generated comment: release notes by coderabbit.ai -->