### PR TITLE
 fix: white toasts show perfectly in white mode and consent log takes full space

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -193,6 +193,7 @@ body {
 
 .toast-info {
   background: var(--blt-bg-light-panel);
+  color: var(--blt-text-primary);
 }
 
 .toast-success {
@@ -710,7 +711,7 @@ html.dark .control-btn.active {
 }
 
 .consent-log {
-  max-height: 760px;
+  max-height: 1160px;
   overflow-y: auto;
 }
 


### PR DESCRIPTION

<img width="875" height="575" alt="consent " src="https://github.com/user-attachments/assets/5d8dca4d-6535-4fb9-a00e-b4295878f22f" />
before 

<img width="1436" height="873" alt="image" src="https://github.com/user-attachments/assets/ae1573c1-4355-4963-adb4-65b4bc80cb4e" />
after 

Also, the toast in light mode now looks like this 
<img width="647" height="416" alt="image" src="https://github.com/user-attachments/assets/84ba1b51-2997-4537-871d-6de0d4cfcac5" />
earlier it looked empty as the text was white coloured 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved info toast message text visibility with explicit color styling
  * Expanded consent log display area to accommodate more content without requiring excessive scrolling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->