### PR TITLE
feat(video-chat): add room-owner badge for creator and stop invite-link auto-join from lobby

### DIFF
--- a/public/js/video-lobby.js
+++ b/public/js/video-lobby.js
@@ -734,7 +734,6 @@
     const displayNameInput = getDisplayNameInput();
     const micBtn = $("btn-preview-mic");
     const camBtn = $("btn-preview-cam");
-    let shouldAutoJoinFromInvite = false;
 
     bindPreviewVoiceControls();
     restoreDisplayNameFromStorage();
@@ -763,7 +762,6 @@
       if (sharedRoomId) {
         roomInput.value = sharedRoomId;
         if (isValidRoomId(sharedRoomId)) {
-          shouldAutoJoinFromInvite = true;
           showToast("Room ID loaded from share link", "info");
         }
 
@@ -868,13 +866,6 @@
       if (camBtn) {
         camBtn.disabled = false;
         camBtn.classList.remove("opacity-50", "cursor-not-allowed");
-      }
-    }
-
-    if (shouldAutoJoinFromInvite) {
-      const existingName = normalizeDisplayName(displayNameInput ? displayNameInput.value : "");
-      if (existingName) {
-        joinRoom();
       }
     }
   });

--- a/public/js/video.js
+++ b/public/js/video.js
@@ -144,7 +144,6 @@ const VideoChat = (() => {
         micMuted: isLocalMicMutedState(),
         camOff: isLocalCamOffState(),
         handRaised: localHandRaised,
-        ownerId: state.ownerId,
       };
     }
     const profile = peerProfiles.get(peerId);
@@ -155,7 +154,6 @@ const VideoChat = (() => {
       micMuted: false,
       camOff: false,
       handRaised: false,
-      ownerId: null,
     };
   }
 
@@ -166,9 +164,7 @@ const VideoChat = (() => {
 
   function isPeerOwner(peerId) {
     if (!peerId) return false;
-    const profile = getProfileForPeer(peerId);
-    const ownerId = profile && profile.ownerId ? profile.ownerId : state.ownerId;
-    return Boolean(ownerId && peerId === ownerId);
+    return Boolean(state.ownerId && peerId === state.ownerId);
   }
 
   function createOwnerBadge() {
@@ -305,7 +301,6 @@ const VideoChat = (() => {
       id: state.peerId,
       name: state.displayName,
       initials: state.displayInitials,
-      ownerId: state.ownerId,
       micMuted: isLocalMicMutedState(),
       camOff: screenSharing ? false : isLocalCamOffState(),
       handRaised: localHandRaised,
@@ -604,20 +599,12 @@ const VideoChat = (() => {
       micMuted: false,
       camOff: false,
       handRaised: false,
-      ownerId: null,
     };
     const normalizedName = normalizeDisplayName(payload && payload.name);
-    const incomingOwnerId =
-      payload && typeof payload.ownerId === "string" ? normalizeRoomId(payload.ownerId) : "";
-
-    if (incomingOwnerId && !state.ownerId) {
-      state.ownerId = incomingOwnerId;
-    }
 
     const profile = {
       name: normalizedName || prev.name,
       initials: makeInitials(normalizedName || prev.name),
-      ownerId: incomingOwnerId || prev.ownerId || null,
       micMuted:
         payload && typeof payload.micMuted === "boolean"
           ? payload.micMuted

--- a/public/js/video.js
+++ b/public/js/video.js
@@ -51,6 +51,7 @@ const VideoChat = (() => {
 
   const state = {
     peerId: null,
+    ownerId: null,
     connected: false,
     sessionId: null,
     sessionKey: null,
@@ -143,6 +144,7 @@ const VideoChat = (() => {
         micMuted: isLocalMicMutedState(),
         camOff: isLocalCamOffState(),
         handRaised: localHandRaised,
+        ownerId: state.ownerId,
       };
     }
     const profile = peerProfiles.get(peerId);
@@ -153,12 +155,30 @@ const VideoChat = (() => {
       micMuted: false,
       camOff: false,
       handRaised: false,
+      ownerId: null,
     };
   }
 
   function getDisplayLabel(peerId) {
     if (peerId === state.peerId || peerId === "local") return "You";
     return getProfileForPeer(peerId).name || peerId;
+  }
+
+  function isPeerOwner(peerId) {
+    if (!peerId) return false;
+    const profile = getProfileForPeer(peerId);
+    const ownerId = profile && profile.ownerId ? profile.ownerId : state.ownerId;
+    return Boolean(ownerId && peerId === ownerId);
+  }
+
+  function createOwnerBadge() {
+    const badge = document.createElement("span");
+    badge.className =
+      "rounded-full bg-amber-100 px-2 py-0.5 text-[10px] font-bold uppercase tracking-wide text-amber-700";
+    badge.textContent = "Owner";
+    badge.setAttribute("aria-label", "Room owner");
+    badge.title = "Room owner";
+    return badge;
   }
 
   function normalizeRoomId(value) {
@@ -285,6 +305,7 @@ const VideoChat = (() => {
       id: state.peerId,
       name: state.displayName,
       initials: state.displayInitials,
+      ownerId: state.ownerId,
       micMuted: isLocalMicMutedState(),
       camOff: screenSharing ? false : isLocalCamOffState(),
       handRaised: localHandRaised,
@@ -583,12 +604,20 @@ const VideoChat = (() => {
       micMuted: false,
       camOff: false,
       handRaised: false,
+      ownerId: null,
     };
     const normalizedName = normalizeDisplayName(payload && payload.name);
+    const incomingOwnerId =
+      payload && typeof payload.ownerId === "string" ? normalizeRoomId(payload.ownerId) : "";
+
+    if (incomingOwnerId && !state.ownerId) {
+      state.ownerId = incomingOwnerId;
+    }
 
     const profile = {
       name: normalizedName || prev.name,
       initials: makeInitials(normalizedName || prev.name),
+      ownerId: incomingOwnerId || prev.ownerId || null,
       micMuted:
         payload && typeof payload.micMuted === "boolean"
           ? payload.micMuted
@@ -1090,7 +1119,9 @@ const VideoChat = (() => {
       return;
     }
     const inviteRoomId = getInviteRoomIdFromUrl();
-    state.peerId = shouldReuseInviteRoomAsPeerId(inviteRoomId) ? inviteRoomId : Crypto.randomId(6);
+    const shouldReuseRoomId = shouldReuseInviteRoomAsPeerId(inviteRoomId);
+    state.peerId = shouldReuseRoomId ? inviteRoomId : Crypto.randomId(6);
+    state.ownerId = isValidRoomId(inviteRoomId) ? inviteRoomId : state.peerId;
     persistOwnRoomId(state.peerId);
     state.sessionKey = await Crypto.generateKey();
     state.sessionId = state.peerId;
@@ -1259,6 +1290,10 @@ const VideoChat = (() => {
     localNameText.textContent = `${state.displayName} (You)`;
     localNameLabel.appendChild(localNameText);
 
+    if (isPeerOwner(state.peerId)) {
+      localNameLabel.appendChild(createOwnerBadge());
+    }
+
     if (localHandRaised) {
       const hand = document.createElement("span");
       hand.textContent = "✋";
@@ -1304,6 +1339,10 @@ const VideoChat = (() => {
       nameText.className = "truncate";
       nameText.textContent = getDisplayLabel(peerId);
       nameLabel.appendChild(nameText);
+
+      if (isPeerOwner(peerId)) {
+        nameLabel.appendChild(createOwnerBadge());
+      }
 
       const remoteProfile = getProfileForPeer(peerId);
       if (remoteProfile.handRaised) {

--- a/public/js/video.js
+++ b/public/js/video.js
@@ -1317,7 +1317,13 @@ const VideoChat = (() => {
     localItem.appendChild(localNameSpan);
     listEl.appendChild(localItem);
 
-    activeCalls.forEach((_call, peerId) => {
+    const orderedPeerIds = Array.from(activeCalls.keys()).sort((a, b) => {
+      const aRank = isPeerOwner(a) ? 0 : 1;
+      const bRank = isPeerOwner(b) ? 0 : 1;
+      return aRank - bRank;
+    });
+
+    orderedPeerIds.forEach((peerId) => {
       const item = document.createElement("div");
       item.className = "flex items-center justify-between gap-2 py-1 text-sm";
 


### PR DESCRIPTION
Auto join before 

https://github.com/user-attachments/assets/e03ec889-df11-47b8-8bf6-b435de26f080

After auto join removed working fine 

https://github.com/user-attachments/assets/4f531966-4c81-4da4-8949-04d3af3987d0

Added a new owner badge for identifcation 
<img width="178" height="98" alt="owner" src="https://github.com/user-attachments/assets/3532b268-52cd-4c18-a49c-ae7f27e627e7" />
Closes #114

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Participants who own the room are marked with an "Owner" badge (shown on local and remote tiles).
  * Owner participants are prioritized and displayed first in the participant list.

* **Changes**
  * Invite share links populate the room field but no longer trigger automatic join; users must explicitly join after entering a valid display name.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->