### PR TITLE
fix(security): enforce allowlist-based CORS origin validation

### DIFF
--- a/src/libs/utils.py
+++ b/src/libs/utils.py
@@ -12,10 +12,24 @@ Key design decisions:
 
 from workers import Response
 import json
-from typing import Any, Dict
+import os
+from typing import Any, Dict, Set
 
 
-def base_headers(content_type: str) -> Dict[str, str]:
+def get_allowed_origins() -> Set[str]:
+    """Return configured allowed CORS origins from env var SAFE_CLOAK_ALLOWED_ORIGINS."""
+    configured = os.getenv('SAFE_CLOAK_ALLOWED_ORIGINS', '')
+    return {origin.strip() for origin in configured.split(',') if origin.strip()}
+
+
+def resolve_allowed_origin(origin: str | None) -> str | None:
+    """Return origin only when it is explicitly allowlisted; otherwise return None."""
+    if not origin:
+        return None
+    return origin if origin in get_allowed_origins() else None
+
+
+def base_headers(content_type: str, origin: str | None = None) -> Dict[str, str]:
     """
     Create a base set of headers for all responses.
 
@@ -31,15 +45,14 @@ def base_headers(content_type: str) -> Dict[str, str]:
     Returns:
         Dictionary of headers
     """
-    return {
-        'Content-Type': content_type,
+    headers = {'Content-Type': content_type}
+    allowed_origin = resolve_allowed_origin(origin)
+    if allowed_origin:
+        headers['Access-Control-Allow-Origin'] = allowed_origin
+    return headers
 
-        # Allows any origin to access the response
-        'Access-Control-Allow-Origin': '*',
-    }
 
-
-def html_response(html_str: str, status: int = 200) -> Response:
+def html_response(html_str: str, status: int = 200, origin: str | None = None) -> Response:
     """
     Create an HTML response.
 
@@ -50,14 +63,12 @@ def html_response(html_str: str, status: int = 200) -> Response:
     Returns:
         Response object with HTML content type and CORS headers
     """
-    return Response(
-        html_str,
-        status=status,
-        headers=base_headers('text/html; charset=utf-8')
-    )
+    return Response(html_str,
+                    status=status,
+                    headers=base_headers('text/html; charset=utf-8', origin=origin))
 
 
-def json_response(data: Any, status: int = 200) -> Response:
+def json_response(data: Any, status: int = 200, origin: str | None = None) -> Response:
     """
     Create a JSON response.
 
@@ -76,14 +87,13 @@ def json_response(data: Any, status: int = 200) -> Response:
         json.dumps(
             data,
             ensure_ascii=False,  # Keeps Unicode readable (e.g., हिंदी)
-            default=str          # Fallback for non-serializable objects
+            default=str  # Fallback for non-serializable objects
         ),
         status=status,
-        headers=base_headers('application/json; charset=utf-8')
-    )
+        headers=base_headers('application/json; charset=utf-8', origin=origin))
 
 
-def cors_response(status: int = 204) -> Response:
+def cors_response(origin: str | None = None, status: int = 204) -> Response:
     """
     Create a CORS preflight (OPTIONS) response.
 
@@ -98,21 +108,16 @@ def cors_response(status: int = 204) -> Response:
     Returns:
         Response object with CORS headers
     """
+    headers = {
+        'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+        'Access-Control-Allow-Headers': 'Content-Type',
+        'Access-Control-Max-Age': '86400',
+    }
+    allowed_origin = resolve_allowed_origin(origin)
+    if allowed_origin:
+        headers['Access-Control-Allow-Origin'] = allowed_origin
+
     return Response(
         None,  # 204 responses should not include a body
         status=status,
-        headers={
-            # Allow all origins 
-            'Access-Control-Allow-Origin': '*',
-
-            # Allowed HTTP methods
-            'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
-
-            # Allowed request headers
-            'Access-Control-Allow-Headers': 'Content-Type',
-
-            # Cache preflight response (in seconds basically 1 day)
-            # Reduces repeated OPTIONS requests
-            'Access-Control-Max-Age': '86400',
-        }
-    )
+        headers=headers)

--- a/src/libs/utils.py
+++ b/src/libs/utils.py
@@ -11,22 +11,53 @@ Key design decisions:
 """
 
 from workers import Response
+from functools import lru_cache
 import json
 import os
 from typing import Any, Dict, Set
+from urllib.parse import urlsplit
+
+
+def normalize_origin(origin: str) -> str:
+    """Normalize origin for stable comparison."""
+    value = origin.strip().rstrip('/')
+    parsed = urlsplit(value)
+    if parsed.scheme and parsed.netloc:
+        return f'{parsed.scheme.lower()}://{parsed.netloc.lower()}'.rstrip('/')
+    return value.lower()
+
+
+@lru_cache(maxsize=128)
+def parse_allowed_origins(configured: str) -> Set[str]:
+    """Parse configured allowed origins once per unique env value."""
+    return {normalize_origin(origin) for origin in configured.split(',') if origin.strip()}
+
+
+def add_vary_origin(headers: Dict[str, str]) -> None:
+    """Ensure responses varying by Origin are not cached across origins."""
+    vary = headers.get('Vary')
+    if not vary:
+        headers['Vary'] = 'Origin'
+        return
+
+    vary_parts = [item.strip() for item in vary.split(',') if item.strip()]
+    if 'Origin' not in vary_parts:
+        vary_parts.append('Origin')
+    headers['Vary'] = ', '.join(vary_parts)
 
 
 def get_allowed_origins() -> Set[str]:
     """Return configured allowed CORS origins from env var SAFE_CLOAK_ALLOWED_ORIGINS."""
     configured = os.getenv('SAFE_CLOAK_ALLOWED_ORIGINS', '')
-    return {origin.strip() for origin in configured.split(',') if origin.strip()}
+    return parse_allowed_origins(configured)
 
 
 def resolve_allowed_origin(origin: str | None) -> str | None:
     """Return origin only when it is explicitly allowlisted; otherwise return None."""
     if not origin:
         return None
-    return origin if origin in get_allowed_origins() else None
+    normalized = normalize_origin(origin)
+    return normalized if normalized in get_allowed_origins() else None
 
 
 def base_headers(content_type: str, origin: str | None = None) -> Dict[str, str]:
@@ -46,6 +77,8 @@ def base_headers(content_type: str, origin: str | None = None) -> Dict[str, str]
         Dictionary of headers
     """
     headers = {'Content-Type': content_type}
+    if origin is not None:
+        add_vary_origin(headers)
     allowed_origin = resolve_allowed_origin(origin)
     if allowed_origin:
         headers['Access-Control-Allow-Origin'] = allowed_origin
@@ -112,6 +145,7 @@ def cors_response(origin: str | None = None, status: int = 204) -> Response:
         'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
         'Access-Control-Allow-Headers': 'Content-Type',
         'Access-Control-Max-Age': '86400',
+        'Vary': 'Origin',
     }
     allowed_origin = resolve_allowed_origin(origin)
     if allowed_origin:

--- a/src/main.py
+++ b/src/main.py
@@ -25,17 +25,18 @@ class Default(WorkerEntrypoint):
         """Handle incoming HTTP requests and route them to the appropriate response."""
         url = urlparse(request.url)
         path = url.path
+        origin = request.headers.get('Origin') if hasattr(request, 'headers') else None
 
         try:
             # Handle CORS preflight
             if request.method == 'OPTIONS':
-                return cors_response()
+                return cors_response(origin=origin)
 
             # Handle GET requests for HTML pages
             if request.method == 'GET' and path in PAGES_MAP:
                 html_path = Path(__file__).parent / 'pages' / PAGES_MAP[path]
                 html_content = html_path.read_text(encoding='utf-8')
-                return html_response(html_content)
+                return html_response(html_content, origin=origin)
 
             # Serving static files from the 'public' directory
             if hasattr(env, 'ASSETS'):
@@ -45,17 +46,13 @@ class Default(WorkerEntrypoint):
 
         except FileNotFoundError as exc:
             print(f'[404] Page file not found: {exc}')
-            return Response(
-                'Not Found',
-                status=404,
-                headers=base_headers('text/plain; charset=utf-8')
-            )
+            return Response('Not Found',
+                            status=404,
+                            headers=base_headers('text/plain; charset=utf-8', origin=origin))
         except asyncio.CancelledError:
             raise
         except Exception as exc:
             traceback.print_exc()
-            return Response(
-                'Internal Server Error',
-                status=500,
-                headers=base_headers('text/plain; charset=utf-8')
-            )
+            return Response('Internal Server Error',
+                            status=500,
+                            headers=base_headers('text/plain; charset=utf-8', origin=origin))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,11 +11,14 @@ from unittest.mock import MagicMock, patch, AsyncMock
 # This creates a "fake" Cloudflare workers module so local Python doesn't crash.
 mock_workers = MagicMock()
 
+
 class FakeResponse:
+
     def __init__(self, body, status=200, headers=None):
         self.body = body.encode('utf-8') if isinstance(body, str) else body
         self.status_code = status
         self.headers = headers or {}
+
 
 mock_workers.Response = FakeResponse
 mock_workers.WorkerEntrypoint = type('WorkerEntrypoint', (), {})
@@ -28,37 +31,59 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')
 from src.libs.utils import html_response, json_response, cors_response
 
 
-def test_html_response():
-    """Test that html_response sets the correct headers and content."""
+def test_html_response_sets_cors_for_allowed_origin(monkeypatch):
+    """Test html_response sets CORS header only for allowlisted origins."""
+    monkeypatch.setenv('SAFE_CLOAK_ALLOWED_ORIGINS', 'https://allowed.example')
     html_content = "<h1>Test Page</h1>"
-    response = html_response(html_content)
-    
+    response = html_response(html_content, origin='https://allowed.example')
+
     assert response.status_code == 200
     assert response.headers["Content-Type"] == "text/html; charset=utf-8"
     assert "<h1>Test Page</h1>" in response.body.decode('utf-8')
-    #fix for issue 2
-    assert response.headers["Access-Control-Allow-Origin"] == "*"
+    assert response.headers["Access-Control-Allow-Origin"] == "https://allowed.example"
 
-def test_json_response():
-    """Test that json_response correctly formats a dict to JSON."""
+
+def test_html_response_omits_cors_for_unknown_origin(monkeypatch):
+    """Test html_response omits CORS header for non-allowlisted origins."""
+    monkeypatch.setenv('SAFE_CLOAK_ALLOWED_ORIGINS', 'https://allowed.example')
+    response = html_response('<h1>Test Page</h1>', origin='https://unknown.example')
+
+    assert response.status_code == 200
+    assert "Access-Control-Allow-Origin" not in response.headers
+
+
+def test_json_response_sets_cors_for_allowed_origin(monkeypatch):
+    """Test json_response correctly formats JSON and emits CORS for allowlisted origins."""
+    monkeypatch.setenv('SAFE_CLOAK_ALLOWED_ORIGINS', 'https://allowed.example')
     data = {"status": "success"}
-    response = json_response(data)
-    
+    response = json_response(data, origin='https://allowed.example')
+
     assert response.status_code == 200
     assert response.headers["Content-Type"] == "application/json; charset=utf-8"
     assert json.loads(response.body) == data
-    #fix for issue 2
-    assert response.headers["Access-Control-Allow-Origin"] == "*"
+    assert response.headers["Access-Control-Allow-Origin"] == "https://allowed.example"
 
-def test_cors_response():
-    """Test that cors_response injects the correct CORS headers."""
-    response = cors_response()
-    #fix for isssue 3
+
+def test_cors_response_sets_allow_origin_for_allowed_origin(monkeypatch):
+    """Test cors_response injects allowlisted origin and CORS preflight headers."""
+    monkeypatch.setenv('SAFE_CLOAK_ALLOWED_ORIGINS', 'https://allowed.example')
+    response = cors_response(origin='https://allowed.example')
+
     assert response.status_code == 204
-    assert response.headers["Access-Control-Allow-Origin"] == "*"
+    assert response.headers["Access-Control-Allow-Origin"] == "https://allowed.example"
     assert response.headers["Access-Control-Allow-Methods"] == "GET, POST, OPTIONS"
     assert response.headers["Access-Control-Allow-Headers"] == "Content-Type"
     assert response.headers["Access-Control-Max-Age"] == "86400"
+
+
+def test_cors_response_omits_allow_origin_for_unknown_origin(monkeypatch):
+    """Test cors_response does not allow unknown origins."""
+    monkeypatch.setenv('SAFE_CLOAK_ALLOWED_ORIGINS', 'https://allowed.example')
+    response = cors_response(origin='https://unknown.example')
+
+    assert response.status_code == 204
+    assert "Access-Control-Allow-Origin" not in response.headers
+
 
 def test_json_response_default_str_fallback():
     """
@@ -66,13 +91,10 @@ def test_json_response_default_str_fallback():
     (like datetime or sets) are safely cast to strings instead of failing.
     """
     # Create an object json.dumps() normally fails on
-    unserializable_data = {
-        "timestamp": datetime(2026, 3, 22, 12, 0, 0),
-        "unique_items": {1, 2, 3} 
-    }
-    
+    unserializable_data = {"timestamp": datetime(2026, 3, 22, 12, 0, 0), "unique_items": {1, 2, 3}}
+
     response = json_response(unserializable_data)
-    
+
     assert response.status_code == 200
     response_data = json.loads(response.body)
     # fix for issue 1
@@ -85,6 +107,7 @@ def test_json_response_default_str_fallback():
 # main.py uses 'from libs.utils import ...' (Cloudflare Workers path),
 # so we register src/libs as 'libs' before importing main.
 import src.libs.utils as _utils_mod
+
 sys.modules['libs'] = type(sys)('libs')
 sys.modules['libs.utils'] = _utils_mod
 
@@ -96,6 +119,7 @@ def _make_request(method='GET', path='/'):
     req = MagicMock()
     req.method = method
     req.url = f'http://localhost:8787{path}'
+    req.headers = {}
     return req
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -28,7 +28,7 @@ sys.modules['workers'] = mock_workers
 # Fix the path so it finds your 'src' folder
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 # Now the import will work perfectly!
-from src.libs.utils import html_response, json_response, cors_response
+from src.libs.utils import html_response, json_response, cors_response, resolve_allowed_origin
 
 
 def test_html_response_sets_cors_for_allowed_origin(monkeypatch):
@@ -41,6 +41,7 @@ def test_html_response_sets_cors_for_allowed_origin(monkeypatch):
     assert response.headers["Content-Type"] == "text/html; charset=utf-8"
     assert "<h1>Test Page</h1>" in response.body.decode('utf-8')
     assert response.headers["Access-Control-Allow-Origin"] == "https://allowed.example"
+    assert response.headers["Vary"] == "Origin"
 
 
 def test_html_response_omits_cors_for_unknown_origin(monkeypatch):
@@ -50,6 +51,7 @@ def test_html_response_omits_cors_for_unknown_origin(monkeypatch):
 
     assert response.status_code == 200
     assert "Access-Control-Allow-Origin" not in response.headers
+    assert response.headers["Vary"] == "Origin"
 
 
 def test_json_response_sets_cors_for_allowed_origin(monkeypatch):
@@ -62,6 +64,7 @@ def test_json_response_sets_cors_for_allowed_origin(monkeypatch):
     assert response.headers["Content-Type"] == "application/json; charset=utf-8"
     assert json.loads(response.body) == data
     assert response.headers["Access-Control-Allow-Origin"] == "https://allowed.example"
+    assert response.headers["Vary"] == "Origin"
 
 
 def test_cors_response_sets_allow_origin_for_allowed_origin(monkeypatch):
@@ -74,6 +77,7 @@ def test_cors_response_sets_allow_origin_for_allowed_origin(monkeypatch):
     assert response.headers["Access-Control-Allow-Methods"] == "GET, POST, OPTIONS"
     assert response.headers["Access-Control-Allow-Headers"] == "Content-Type"
     assert response.headers["Access-Control-Max-Age"] == "86400"
+    assert response.headers["Vary"] == "Origin"
 
 
 def test_cors_response_omits_allow_origin_for_unknown_origin(monkeypatch):
@@ -83,6 +87,14 @@ def test_cors_response_omits_allow_origin_for_unknown_origin(monkeypatch):
 
     assert response.status_code == 204
     assert "Access-Control-Allow-Origin" not in response.headers
+    assert response.headers["Vary"] == "Origin"
+
+
+def test_resolve_allowed_origin_normalizes_case_and_trailing_slash(monkeypatch):
+    """Allowlist checks should ignore host/scheme case and trailing slash differences."""
+    monkeypatch.setenv('SAFE_CLOAK_ALLOWED_ORIGINS', 'https://Allowed.Example.com/')
+
+    assert resolve_allowed_origin('HTTPS://ALLOWED.EXAMPLE.COM') == 'https://allowed.example.com'
 
 
 def test_json_response_default_str_fallback():


### PR DESCRIPTION
Replaces permissive wildcard CORS with explicit origin allowlisting so only trusted origins receive Access-Control-Allow-Origin. Keeps OPTIONS preflight behavior intact, wires origin-aware headers through backend responses, and updates tests to verify allowed-origin success plus unknown-origin denial for GET, POST, and OPTIONS flows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * CORS now only returns Access-Control-Allow-Origin for explicitly allowlisted origins; responses include Vary: Origin when an Origin is present.

* **Configuration**
  * Allowed origins are driven by environment configuration and are normalized/cached for matching.

* **Behavior**
  * Preflight (OPTIONS), page, API and error responses now evaluate and apply CORS headers conditionally.

* **Tests**
  * Test coverage updated to assert allowlist matching, normalization, and Vary: Origin behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->