### PR TITLE
fix(walkie): force walkie invite mode on and locked; preserve walkie in shared room links

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -850,8 +850,21 @@ html.dark .control-btn.active {
 }
 
 html.dark .ptt-ready {
-  background: #2563eb !important;
-  border-color: #2563eb !important;
+  background: #1d4ed8 !important;
+  background-color: #1d4ed8 !important;
+  border-color: #1d4ed8 !important;
+}
+
+html.dark .control-btn.ptt-ready {
+  background: #1d4ed8 !important;
+  background-color: #1d4ed8 !important;
+  border-color: #1d4ed8 !important;
+}
+
+html.dark .control-btn.ptt-ready:hover {
+  background: #1e40af !important;
+  background-color: #1e40af !important;
+  border-color: #1e40af !important;
 }
 
 @keyframes ptt-pulse {

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -857,23 +857,23 @@ html.dark .ptt-ready {
 @keyframes ptt-pulse {
   0%,
   100% {
-    box-shadow: 0 0 0 0 rgba(22, 163, 74, 0.4);
+    box-shadow: 0 0 0 0 rgba(239, 68, 68, 0.4);
   }
   50% {
-    box-shadow: 0 0 0 10px rgba(22, 163, 74, 0);
+    box-shadow: 0 0 0 10px rgba(239, 68, 68, 0);
   }
 }
 
 .ptt-speaking {
-  background: #166534 !important;
-  border-color: #16a34a !important;
+  background: #b91c1c !important;
+  border-color: #ef4444 !important;
   color: #ffffff !important;
   animation: ptt-pulse 1s ease-in-out infinite;
 }
 
 html.dark .ptt-speaking {
-  background: #166534 !important;
-  border-color: #16a34a !important;
+  background: #dc2626 !important;
+  border-color: #ef4444 !important;
 }
 
 /* ============================================

--- a/public/js/video-lobby.js
+++ b/public/js/video-lobby.js
@@ -734,7 +734,14 @@
     const displayNameInput = getDisplayNameInput();
     const micBtn = $("btn-preview-mic");
     const camBtn = $("btn-preview-cam");
+    const params = new URLSearchParams(window.location.search);
+    const sharedRoomId = normalizeRoomId(params.get("room"));
+    const walkieLockedFromInvite = params.get("walkie") === "1" && isValidRoomId(sharedRoomId);
     let shouldAutoJoinFromInvite = false;
+
+    if (walkieLockedFromInvite) {
+      walkieTalkieEnabled = true;
+    }
 
     bindPreviewVoiceControls();
     restoreDisplayNameFromStorage();
@@ -758,8 +765,6 @@
         }
       });
 
-      const params = new URLSearchParams(window.location.search);
-      const sharedRoomId = normalizeRoomId(params.get("room"));
       if (sharedRoomId) {
         roomInput.value = sharedRoomId;
         if (isValidRoomId(sharedRoomId)) {
@@ -832,6 +837,14 @@
 
     const walkieToggle = $("toggle-walkie-talkie");
     if (walkieToggle) {
+      walkieToggle.checked = walkieTalkieEnabled;
+      walkieToggle.setAttribute("aria-checked", String(walkieTalkieEnabled));
+      if (walkieLockedFromInvite) {
+        walkieToggle.disabled = true;
+        walkieToggle.setAttribute("aria-disabled", "true");
+        walkieToggle.title = "Locked by walkie-talkie invite link";
+      }
+
       walkieToggle.addEventListener("change", async () => {
         walkieTalkieEnabled = walkieToggle.checked;
         walkieToggle.setAttribute("aria-checked", String(walkieTalkieEnabled));

--- a/public/js/video.js
+++ b/public/js/video.js
@@ -908,6 +908,14 @@ const VideoChat = (() => {
     pushToTalkPressed = true;
     syncControlButtons();
     const claimed = await claimWalkieFloor();
+
+    // If the button was released while claim was pending, immediately relinquish the floor.
+    if (claimed && !pushToTalkPressed) {
+      await releaseWalkieFloor();
+      syncControlButtons();
+      return;
+    }
+
     if (!claimed && walkieFloorHolder !== state.peerId) {
       pushToTalkPressed = false;
       syncControlButtons();

--- a/public/js/video.js
+++ b/public/js/video.js
@@ -43,6 +43,7 @@ const VideoChat = (() => {
   let isEndingCall = false;
   let walkieTalkieMode = false;
   let walkieFloorHolder = null;
+  let pushToTalkPressed = false;
   let wasMicMutedBeforeWalkie = true;
   let wasCamOffBeforeWalkie = true;
   let reconnectAttempts = 0;
@@ -778,16 +779,20 @@ const VideoChat = (() => {
     const pushToTalkBtn = $("btn-push-to-talk");
     if (pushToTalkBtn) {
       const isSpeaking = walkieTalkieMode && walkieFloorHolder === state.peerId && !micMuted;
+      const isHeld = walkieTalkieMode && pushToTalkPressed;
+      const isActive = isSpeaking || isHeld;
       pushToTalkBtn.classList.toggle("hidden", !walkieTalkieMode);
-      pushToTalkBtn.classList.toggle("ptt-ready", walkieTalkieMode && !isSpeaking);
-      pushToTalkBtn.classList.toggle("ptt-speaking", isSpeaking);
-      pushToTalkBtn.setAttribute("aria-pressed", isSpeaking ? "true" : "false");
+      pushToTalkBtn.classList.toggle("ptt-ready", walkieTalkieMode && !isActive);
+      pushToTalkBtn.classList.toggle("ptt-speaking", isActive);
+      pushToTalkBtn.classList.toggle("active", isActive);
+      pushToTalkBtn.setAttribute("aria-pressed", isActive ? "true" : "false");
       pushToTalkBtn.disabled = !walkieTalkieMode;
     }
   }
 
   async function setWalkieTalkieMode(enabled) {
     if (walkieTalkieMode === enabled) return;
+    pushToTalkPressed = false;
     if (!enabled) {
       await releaseWalkieFloor();
     }
@@ -900,11 +905,19 @@ const VideoChat = (() => {
 
   async function onPushToTalkStart() {
     if (!walkieTalkieMode) return;
-    await claimWalkieFloor();
+    pushToTalkPressed = true;
+    syncControlButtons();
+    const claimed = await claimWalkieFloor();
+    if (!claimed && walkieFloorHolder !== state.peerId) {
+      pushToTalkPressed = false;
+      syncControlButtons();
+    }
   }
 
   async function onPushToTalkEnd() {
     if (!walkieTalkieMode) return;
+    pushToTalkPressed = false;
+    syncControlButtons();
     await releaseWalkieFloor();
   }
 
@@ -2408,8 +2421,12 @@ const VideoChat = (() => {
       showToast("Room not ready yet — please wait", "warning");
       return;
     }
-    const url = `${window.location.origin}/video-chat?room=${encodeURIComponent(state.peerId)}`;
-    copyToClipboard(url, "Room link");
+    const url = new URL(`${window.location.origin}/video-chat`);
+    url.searchParams.set("room", state.peerId);
+    if (walkieTalkieMode) {
+      url.searchParams.set("walkie", "1");
+    }
+    copyToClipboard(url.toString(), "Room link");
   }
 
   /**


### PR DESCRIPTION
Closes #117 
Closes #118

Also makes the push to talk button blue just like in white mode 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Invite links can lock walkie-talkie mode on join, preventing manual toggles.
  * Push-to-talk button has improved held-state handling and more reliable floor-claim behavior.
  * Shared room links now preserve walkie-talkie mode when generated.

* **Style**
  * Push-to-talk "speaking" indicator changed from green to red (light and dark).
  * Dark-theme "ready" and control button ready/hover colors adjusted for clearer contrast.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->