### PR TITLE
fix(security): add default response security headers

### DIFF
--- a/src/libs/utils.py
+++ b/src/libs/utils.py
@@ -14,25 +14,28 @@ from workers import Response
 import json
 from typing import Any, Dict
 
+SECURITY_HEADERS: Dict[str, str] = {
+    'X-Content-Type-Options':
+    'nosniff',
+    'X-Frame-Options':
+    'DENY',
+    'Referrer-Policy':
+    'strict-origin-when-cross-origin',
+    'Content-Security-Policy-Report-Only':
+    ("default-src 'self'; base-uri 'self'; object-src 'none'; "
+     "frame-ancestors 'none'; form-action 'self'"),
+}
+
 
 def security_headers() -> Dict[str, str]:
     """
     Return security headers that should be present on every response.
 
     CSP is report-only here to avoid breaking existing inline assets while
-    still surfacing violations during testing and monitoring.
+    still surfacing violations during testing and monitoring. No reporting
+    endpoint is configured, so violations stay local to browser/devtools logs.
     """
-    return {
-        'X-Content-Type-Options':
-        'nosniff',
-        'X-Frame-Options':
-        'DENY',
-        'Referrer-Policy':
-        'strict-origin-when-cross-origin',
-        'Content-Security-Policy-Report-Only':
-        ("default-src 'self'; base-uri 'self'; object-src 'none'; "
-         "frame-ancestors 'none'; form-action 'self'"),
-    }
+    return SECURITY_HEADERS.copy()
 
 
 def base_headers(content_type: str) -> Dict[str, str]:

--- a/src/libs/utils.py
+++ b/src/libs/utils.py
@@ -15,6 +15,26 @@ import json
 from typing import Any, Dict
 
 
+def security_headers() -> Dict[str, str]:
+    """
+    Return security headers that should be present on every response.
+
+    CSP is report-only here to avoid breaking existing inline assets while
+    still surfacing violations during testing and monitoring.
+    """
+    return {
+        'X-Content-Type-Options':
+        'nosniff',
+        'X-Frame-Options':
+        'DENY',
+        'Referrer-Policy':
+        'strict-origin-when-cross-origin',
+        'Content-Security-Policy-Report-Only':
+        ("default-src 'self'; base-uri 'self'; object-src 'none'; "
+         "frame-ancestors 'none'; form-action 'self'"),
+    }
+
+
 def base_headers(content_type: str) -> Dict[str, str]:
     """
     Create a base set of headers for all responses.
@@ -36,6 +56,7 @@ def base_headers(content_type: str) -> Dict[str, str]:
 
         # Allows any origin to access the response
         'Access-Control-Allow-Origin': '*',
+        **security_headers(),
     }
 
 
@@ -50,11 +71,7 @@ def html_response(html_str: str, status: int = 200) -> Response:
     Returns:
         Response object with HTML content type and CORS headers
     """
-    return Response(
-        html_str,
-        status=status,
-        headers=base_headers('text/html; charset=utf-8')
-    )
+    return Response(html_str, status=status, headers=base_headers('text/html; charset=utf-8'))
 
 
 def json_response(data: Any, status: int = 200) -> Response:
@@ -76,11 +93,10 @@ def json_response(data: Any, status: int = 200) -> Response:
         json.dumps(
             data,
             ensure_ascii=False,  # Keeps Unicode readable (e.g., हिंदी)
-            default=str          # Fallback for non-serializable objects
+            default=str  # Fallback for non-serializable objects
         ),
         status=status,
-        headers=base_headers('application/json; charset=utf-8')
-    )
+        headers=base_headers('application/json; charset=utf-8'))
 
 
 def cors_response(status: int = 204) -> Response:
@@ -102,7 +118,9 @@ def cors_response(status: int = 204) -> Response:
         None,  # 204 responses should not include a body
         status=status,
         headers={
-            # Allow all origins 
+            **security_headers(),
+
+            # Allow all origins
             'Access-Control-Allow-Origin': '*',
 
             # Allowed HTTP methods
@@ -114,5 +132,4 @@ def cors_response(status: int = 204) -> Response:
             # Cache preflight response (in seconds basically 1 day)
             # Reduces repeated OPTIONS requests
             'Access-Control-Max-Age': '86400',
-        }
-    )
+        })

--- a/src/main.py
+++ b/src/main.py
@@ -41,21 +41,19 @@ class Default(WorkerEntrypoint):
             if hasattr(env, 'ASSETS'):
                 return await env.ASSETS.fetch(request)
 
-            return Response('Not Found', status=404)
+            return Response('Not Found',
+                            status=404,
+                            headers=base_headers('text/plain; charset=utf-8'))
 
         except FileNotFoundError as exc:
             print(f'[404] Page file not found: {exc}')
-            return Response(
-                'Not Found',
-                status=404,
-                headers=base_headers('text/plain; charset=utf-8')
-            )
+            return Response('Not Found',
+                            status=404,
+                            headers=base_headers('text/plain; charset=utf-8'))
         except asyncio.CancelledError:
             raise
         except Exception as exc:
             traceback.print_exc()
-            return Response(
-                'Internal Server Error',
-                status=500,
-                headers=base_headers('text/plain; charset=utf-8')
-            )
+            return Response('Internal Server Error',
+                            status=500,
+                            headers=base_headers('text/plain; charset=utf-8'))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,11 +11,14 @@ from unittest.mock import MagicMock, patch, AsyncMock
 # This creates a "fake" Cloudflare workers module so local Python doesn't crash.
 mock_workers = MagicMock()
 
+
 class FakeResponse:
+
     def __init__(self, body, status=200, headers=None):
         self.body = body.encode('utf-8') if isinstance(body, str) else body
         self.status_code = status
         self.headers = headers or {}
+
 
 mock_workers.Response = FakeResponse
 mock_workers.WorkerEntrypoint = type('WorkerEntrypoint', (), {})
@@ -27,38 +30,57 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')
 # Now the import will work perfectly!
 from src.libs.utils import html_response, json_response, cors_response
 
+EXPECTED_SECURITY_HEADERS = {
+    "X-Content-Type-Options":
+    "nosniff",
+    "X-Frame-Options":
+    "DENY",
+    "Referrer-Policy":
+    "strict-origin-when-cross-origin",
+    "Content-Security-Policy-Report-Only":
+    ("default-src 'self'; base-uri 'self'; object-src 'none'; "
+     "frame-ancestors 'none'; form-action 'self'"),
+}
+
 
 def test_html_response():
     """Test that html_response sets the correct headers and content."""
     html_content = "<h1>Test Page</h1>"
     response = html_response(html_content)
-    
+
     assert response.status_code == 200
     assert response.headers["Content-Type"] == "text/html; charset=utf-8"
-    assert "<h1>Test Page</h1>" in response.body.decode('utf-8')
-    #fix for issue 2
     assert response.headers["Access-Control-Allow-Origin"] == "*"
+    for header_name, expected_value in EXPECTED_SECURITY_HEADERS.items():
+        assert response.headers[header_name] == expected_value
+    assert "<h1>Test Page</h1>" in response.body.decode('utf-8')
+
 
 def test_json_response():
     """Test that json_response correctly formats a dict to JSON."""
     data = {"status": "success"}
     response = json_response(data)
-    
+
     assert response.status_code == 200
     assert response.headers["Content-Type"] == "application/json; charset=utf-8"
-    assert json.loads(response.body) == data
-    #fix for issue 2
     assert response.headers["Access-Control-Allow-Origin"] == "*"
+    for header_name, expected_value in EXPECTED_SECURITY_HEADERS.items():
+        assert response.headers[header_name] == expected_value
+    assert json.loads(response.body) == data
+
 
 def test_cors_response():
     """Test that cors_response injects the correct CORS headers."""
     response = cors_response()
-    #fix for isssue 3
+
     assert response.status_code == 204
     assert response.headers["Access-Control-Allow-Origin"] == "*"
     assert response.headers["Access-Control-Allow-Methods"] == "GET, POST, OPTIONS"
     assert response.headers["Access-Control-Allow-Headers"] == "Content-Type"
     assert response.headers["Access-Control-Max-Age"] == "86400"
+    for header_name, expected_value in EXPECTED_SECURITY_HEADERS.items():
+        assert response.headers[header_name] == expected_value
+
 
 def test_json_response_default_str_fallback():
     """
@@ -66,13 +88,10 @@ def test_json_response_default_str_fallback():
     (like datetime or sets) are safely cast to strings instead of failing.
     """
     # Create an object json.dumps() normally fails on
-    unserializable_data = {
-        "timestamp": datetime(2026, 3, 22, 12, 0, 0),
-        "unique_items": {1, 2, 3} 
-    }
-    
+    unserializable_data = {"timestamp": datetime(2026, 3, 22, 12, 0, 0), "unique_items": {1, 2, 3}}
+
     response = json_response(unserializable_data)
-    
+
     assert response.status_code == 200
     response_data = json.loads(response.body)
     # fix for issue 1
@@ -85,6 +104,7 @@ def test_json_response_default_str_fallback():
 # main.py uses 'from libs.utils import ...' (Cloudflare Workers path),
 # so we register src/libs as 'libs' before importing main.
 import src.libs.utils as _utils_mod
+
 sys.modules['libs'] = type(sys)('libs')
 sys.modules['libs.utils'] = _utils_mod
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -29,17 +29,13 @@ sys.modules['workers'] = mock_workers
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 # Now the import will work perfectly!
 from src.libs.utils import html_response, json_response, cors_response
+from src.libs.utils import security_headers
 
-EXPECTED_SECURITY_HEADERS = {
-    "X-Content-Type-Options":
-    "nosniff",
-    "X-Frame-Options":
-    "DENY",
-    "Referrer-Policy":
-    "strict-origin-when-cross-origin",
-    "Content-Security-Policy-Report-Only":
-    ("default-src 'self'; base-uri 'self'; object-src 'none'; "
-     "frame-ancestors 'none'; form-action 'self'"),
+EXPECTED_SECURITY_HEADERS = security_headers()
+CRITICAL_SECURITY_DIRECTIVES = {
+    "X-Content-Type-Options": "nosniff",
+    "X-Frame-Options": "DENY",
+    "Referrer-Policy": "strict-origin-when-cross-origin",
 }
 
 
@@ -51,7 +47,10 @@ def test_html_response():
     assert response.status_code == 200
     assert response.headers["Content-Type"] == "text/html; charset=utf-8"
     assert response.headers["Access-Control-Allow-Origin"] == "*"
+    assert EXPECTED_SECURITY_HEADERS.items() <= response.headers.items()
     for header_name, expected_value in EXPECTED_SECURITY_HEADERS.items():
+        assert response.headers[header_name] == expected_value
+    for header_name, expected_value in CRITICAL_SECURITY_DIRECTIVES.items():
         assert response.headers[header_name] == expected_value
     assert "<h1>Test Page</h1>" in response.body.decode('utf-8')
 
@@ -64,7 +63,10 @@ def test_json_response():
     assert response.status_code == 200
     assert response.headers["Content-Type"] == "application/json; charset=utf-8"
     assert response.headers["Access-Control-Allow-Origin"] == "*"
+    assert EXPECTED_SECURITY_HEADERS.items() <= response.headers.items()
     for header_name, expected_value in EXPECTED_SECURITY_HEADERS.items():
+        assert response.headers[header_name] == expected_value
+    for header_name, expected_value in CRITICAL_SECURITY_DIRECTIVES.items():
         assert response.headers[header_name] == expected_value
     assert json.loads(response.body) == data
 
@@ -78,7 +80,10 @@ def test_cors_response():
     assert response.headers["Access-Control-Allow-Methods"] == "GET, POST, OPTIONS"
     assert response.headers["Access-Control-Allow-Headers"] == "Content-Type"
     assert response.headers["Access-Control-Max-Age"] == "86400"
+    assert EXPECTED_SECURITY_HEADERS.items() <= response.headers.items()
     for header_name, expected_value in EXPECTED_SECURITY_HEADERS.items():
+        assert response.headers[header_name] == expected_value
+    for header_name, expected_value in CRITICAL_SECURITY_DIRECTIVES.items():
         assert response.headers[header_name] == expected_value
 
 
@@ -146,6 +151,23 @@ def test_on_fetch_missing_page_returns_404():
             response = asyncio.run(worker.on_fetch(req, env))
 
     assert response.status_code == 404
+    assert b'Not Found' in response.body
+
+
+def test_on_fetch_unknown_path_returns_404_with_security_headers():
+    """Verify that a missing route returns a secure 404 response."""
+    worker = Default()
+    req = _make_request('GET', '/missing-route')
+    env = _make_env()
+
+    response = asyncio.run(worker.on_fetch(req, env))
+
+    assert response.status_code == 404
+    assert response.headers["Content-Type"] == "text/plain; charset=utf-8"
+    assert response.headers["Access-Control-Allow-Origin"] == "*"
+    assert EXPECTED_SECURITY_HEADERS.items() <= response.headers.items()
+    for header_name, expected_value in EXPECTED_SECURITY_HEADERS.items():
+        assert response.headers[header_name] == expected_value
     assert b'Not Found' in response.body
 
 


### PR DESCRIPTION
Add shared security headers to all server responses in utils.py so HTML, JSON, and OPTIONS replies include `X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`, and a report-only CSP, with tests updated to verify the new defaults.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic security headers, including Content Security Policy in report-only mode, to all API responses.

* **Tests**
  * Added validation tests to ensure security headers are properly applied across all response types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->