### PR TITLE
feat: implement resizable sidebar for video room

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -1045,3 +1045,10 @@ html.dark .sidebar-splitter:focus-visible {
   background: var(--blt-primary);
   box-shadow: 0 0 8px rgba(225, 1, 1, 0.5);
 }
+
+/* Responsive overrides for sidebar */
+@media (max-width: 1279px) {
+  #sidebar-content {
+    width: 100% !important;
+  }
+}

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -1001,3 +1001,32 @@ html.dark .border-blue-200 {
 html.dark .border-green-300 {
   border-color: rgba(22, 163, 74, 0.4) !important;
 }
+
+/* === Sidebar Splitter === */
+.sidebar-splitter {
+  width: 4px;
+  min-width: 4px;
+  background: var(--blt-border);
+  cursor: col-resize;
+  user-select: none;
+  transition: background 0.2s ease;
+  flex-shrink: 0;
+}
+
+.sidebar-splitter:hover {
+  background: var(--blt-primary);
+  box-shadow: 0 0 8px rgba(225, 1, 1, 0.3);
+}
+
+.sidebar-splitter.active {
+  background: var(--blt-primary);
+}
+
+html.dark .sidebar-splitter {
+  background: var(--blt-border);
+}
+
+html.dark .sidebar-splitter:hover {
+  background: var(--blt-primary);
+  box-shadow: 0 0 8px rgba(225, 1, 1, 0.5);
+}

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -1011,11 +1011,25 @@ html.dark .border-green-300 {
   user-select: none;
   transition: background 0.2s ease;
   flex-shrink: 0;
+  position: relative; /* For pseudo-element hit area */
 }
 
-.sidebar-splitter:hover {
+.sidebar-splitter:hover,
+.sidebar-splitter:focus-visible {
   background: var(--blt-primary);
   box-shadow: 0 0 8px rgba(225, 1, 1, 0.3);
+  outline: none;
+}
+
+.sidebar-splitter::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: -8px;
+  right: -8px;
+  cursor: col-resize;
+  z-index: 10;
 }
 
 .sidebar-splitter.active {
@@ -1026,7 +1040,8 @@ html.dark .sidebar-splitter {
   background: var(--blt-border);
 }
 
-html.dark .sidebar-splitter:hover {
+html.dark .sidebar-splitter:hover,
+html.dark .sidebar-splitter:focus-visible {
   background: var(--blt-primary);
   box-shadow: 0 0 8px rgba(225, 1, 1, 0.5);
 }

--- a/public/js/ui.js
+++ b/public/js/ui.js
@@ -135,3 +135,141 @@ function formatDateShort(ts) {
   if (diff < 86400000) return `${Math.floor(diff / 3600000)}h ago`;
   return d.toLocaleDateString();
 }
+
+/* ── Sidebar Resize Handler ── */
+class SidebarResize {
+  constructor() {
+    this.splitter = document.getElementById("sidebar-splitter");
+    this.sidebar = document.getElementById("sidebar-content");
+    this.mainGrid = document.getElementById("main-grid");
+
+    // Configuration
+    this.minWidth = 200; // Minimum sidebar width (px)
+    this.maxWidth = 500; // Maximum sidebar width (px)
+    this.isDragging = false;
+    this.startX = 0;
+    this.startWidth = 0;
+
+    if (this.splitter && this.sidebar) {
+      this.init();
+    }
+  }
+
+  init() {
+    // Mouse events
+    this.splitter.addEventListener("mousedown", (e) => this.handleMouseDown(e));
+    document.addEventListener("mousemove", (e) => this.handleMouseMove(e));
+    document.addEventListener("mouseup", () => this.handleMouseUp());
+
+    // Touch events for mobile
+    this.splitter.addEventListener("touchstart", (e) => this.handleTouchStart(e));
+    document.addEventListener("touchmove", (e) => this.handleTouchMove(e));
+    document.addEventListener("touchend", () => this.handleMouseUp());
+
+    // Keyboard support (arrow keys)
+    this.splitter.addEventListener("keydown", (e) => this.handleKeyDown(e));
+
+    // Restore saved width on load
+    this.restoreWidth();
+  }
+
+  handleMouseDown(e) {
+    this.startDrag(e.clientX);
+  }
+
+  handleTouchStart(e) {
+    if (e.touches.length === 1) {
+      this.startDrag(e.touches[0].clientX);
+    }
+  }
+
+  startDrag(clientX) {
+    this.isDragging = true;
+    this.startX = clientX;
+    this.startWidth = this.sidebar.offsetWidth;
+
+    this.splitter.classList.add("active");
+    document.body.style.cursor = "col-resize";
+    document.body.style.userSelect = "none";
+  }
+
+  handleMouseMove(e) {
+    if (!this.isDragging) return;
+    this.resizeSidebar(e.clientX);
+  }
+
+  handleTouchMove(e) {
+    if (!this.isDragging || e.touches.length !== 1) return;
+    this.resizeSidebar(e.touches[0].clientX);
+  }
+
+  handleMouseUp() {
+    if (!this.isDragging) return;
+
+    this.isDragging = false;
+    this.splitter.classList.remove("active");
+    document.body.style.cursor = "default";
+    document.body.style.userSelect = "auto";
+
+    // Save the current width
+    this.saveWidth();
+  }
+
+  handleKeyDown(e) {
+    if (!["ArrowLeft", "ArrowRight"].includes(e.key)) return;
+
+    e.preventDefault();
+    const step = 20;
+    const delta = e.key === "ArrowLeft" ? -step : step;
+    const newWidth = Math.max(
+      this.minWidth,
+      Math.min(this.maxWidth, this.sidebar.offsetWidth + delta)
+    );
+
+    this.sidebar.style.width = `${newWidth}px`;
+    this.saveWidth();
+  }
+
+  resizeSidebar(clientX) {
+    // Calculate the change in position
+    const delta = clientX - this.startX;
+    const newWidth = this.startWidth - delta; // Negative because splitter is on the left of sidebar
+
+    // Apply constraints
+    const constrainedWidth = Math.max(this.minWidth, Math.min(this.maxWidth, newWidth));
+
+    // Update sidebar width
+    this.sidebar.style.width = `${constrainedWidth}px`;
+  }
+
+  saveWidth() {
+    try {
+      localStorage.setItem("blt-sidebar-width", this.sidebar.offsetWidth);
+    } catch (error) {
+      console.warn("[SidebarResize] Failed to save width:", error);
+    }
+  }
+
+  restoreWidth() {
+    try {
+      const savedWidth = localStorage.getItem("blt-sidebar-width");
+      if (savedWidth) {
+        const width = parseInt(savedWidth, 10);
+        if (width >= this.minWidth && width <= this.maxWidth) {
+          this.sidebar.style.width = `${width}px`;
+        }
+      }
+    } catch (error) {
+      console.warn("[SidebarResize] Failed to restore width:", error);
+    }
+  }
+}
+
+// Initialize when DOM is ready
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", () => {
+    new SidebarResize();
+  });
+} else {
+  new SidebarResize();
+}

--- a/public/js/ui.js
+++ b/public/js/ui.js
@@ -141,7 +141,6 @@ class SidebarResize {
   constructor() {
     this.splitter = document.getElementById("sidebar-splitter");
     this.sidebar = document.getElementById("sidebar-content");
-    this.mainGrid = document.getElementById("main-grid");
 
     // Configuration
     this.minWidth = 200; // Minimum sidebar width (px)
@@ -156,14 +155,22 @@ class SidebarResize {
   }
 
   init() {
+    // Set initial ARIA attributes
+    this.splitter.setAttribute("aria-valuemin", this.minWidth);
+    this.splitter.setAttribute("aria-valuemax", this.maxWidth);
+
     // Mouse events
     this.splitter.addEventListener("mousedown", (e) => this.handleMouseDown(e));
     document.addEventListener("mousemove", (e) => this.handleMouseMove(e));
     document.addEventListener("mouseup", () => this.handleMouseUp());
 
-    // Touch events for mobile
-    this.splitter.addEventListener("touchstart", (e) => this.handleTouchStart(e));
-    document.addEventListener("touchmove", (e) => this.handleTouchMove(e));
+    // Touch events for mobile - non-passive to allow preventDefault
+    this.splitter.addEventListener("touchstart", (e) => this.handleTouchStart(e), {
+      passive: false,
+    });
+    document.addEventListener("touchmove", (e) => this.handleTouchMove(e), {
+      passive: false,
+    });
     document.addEventListener("touchend", () => this.handleMouseUp());
 
     // Keyboard support (arrow keys)
@@ -200,6 +207,8 @@ class SidebarResize {
 
   handleTouchMove(e) {
     if (!this.isDragging || e.touches.length !== 1) return;
+    // Prevent scrolling during drag
+    e.preventDefault();
     this.resizeSidebar(e.touches[0].clientX);
   }
 
@@ -208,38 +217,65 @@ class SidebarResize {
 
     this.isDragging = false;
     this.splitter.classList.remove("active");
-    document.body.style.cursor = "default";
-    document.body.style.userSelect = "auto";
+    // Clear inline styles to restore stylesheet values
+    document.body.style.cursor = "";
+    document.body.style.userSelect = "";
 
-    // Save the current width
+    // Final save (applyWidth already saves, but ensure consistency)
     this.saveWidth();
   }
 
   handleKeyDown(e) {
-    if (!["ArrowLeft", "ArrowRight"].includes(e.key)) return;
+    const keys = ["ArrowLeft", "ArrowRight", "Home", "End", "PageUp", "PageDown"];
+    if (!keys.includes(e.key)) return;
 
     e.preventDefault();
     const step = 20;
-    const delta = e.key === "ArrowLeft" ? -step : step;
-    const newWidth = Math.max(
-      this.minWidth,
-      Math.min(this.maxWidth, this.sidebar.offsetWidth + delta)
-    );
+    let newWidth = this.sidebar.offsetWidth;
 
-    this.sidebar.style.width = `${newWidth}px`;
-    this.saveWidth();
+    switch (e.key) {
+      case "ArrowLeft":
+        newWidth -= step;
+        break;
+      case "ArrowRight":
+        newWidth += step;
+        break;
+      case "Home":
+        newWidth = this.minWidth;
+        break;
+      case "End":
+        newWidth = this.maxWidth;
+        break;
+      case "PageUp":
+        newWidth -= step * 4;
+        break;
+      case "PageDown":
+        newWidth += step * 4;
+        break;
+    }
+
+    this.applyWidth(newWidth);
   }
 
   resizeSidebar(clientX) {
     // Calculate the change in position
     const delta = clientX - this.startX;
     const newWidth = this.startWidth - delta; // Negative because splitter is on the left of sidebar
+    this.applyWidth(newWidth);
+  }
 
+  applyWidth(newWidth) {
     // Apply constraints
     const constrainedWidth = Math.max(this.minWidth, Math.min(this.maxWidth, newWidth));
 
     // Update sidebar width
     this.sidebar.style.width = `${constrainedWidth}px`;
+
+    // Update ARIA for assistive tech
+    this.splitter.setAttribute("aria-valuenow", constrainedWidth);
+
+    // Persist
+    this.saveWidth();
   }
 
   saveWidth() {
@@ -255,9 +291,10 @@ class SidebarResize {
       const savedWidth = localStorage.getItem("blt-sidebar-width");
       if (savedWidth) {
         const width = parseInt(savedWidth, 10);
-        if (width >= this.minWidth && width <= this.maxWidth) {
-          this.sidebar.style.width = `${width}px`;
-        }
+        this.applyWidth(width);
+      } else {
+        // Set initial valuenow if no saved width
+        this.applyWidth(this.sidebar.offsetWidth);
       }
     } catch (error) {
       console.warn("[SidebarResize] Failed to restore width:", error);

--- a/src/pages/video-room.html
+++ b/src/pages/video-room.html
@@ -165,7 +165,7 @@
           </div>
         </div>
 
-        <div class="flex gap-4" id="main-grid" style="min-height: 0">
+        <div class="flex flex-col xl:flex-row gap-4" id="main-grid" style="min-height: 0">
           <section class="flex min-h-[64vh] flex-col gap-4 pb-52 flex-1" style="min-width: 0">
             <div
               class="video-grid rounded-2xl border border-neutral-border bg-white p-3 shadow-sm"
@@ -397,7 +397,7 @@
             </div>
           </section>
 
-          <div class="sidebar-splitter" id="sidebar-splitter" role="separator" aria-label="Resize sidebar" aria-orientation="vertical" tabindex="0"></div>
+          <div class="sidebar-splitter hidden xl:block" id="sidebar-splitter" role="separator" aria-label="Resize sidebar" aria-orientation="vertical" tabindex="0" aria-valuemin="200" aria-valuemax="500"></div>
 
           <aside id="sidebar-content" aria-label="Room setup and connection info" class="space-y-4" style="width: 320px; flex-shrink: 0">
             <div class="rounded-2xl border border-neutral-border bg-white p-4 shadow-sm">

--- a/src/pages/video-room.html
+++ b/src/pages/video-room.html
@@ -165,8 +165,8 @@
           </div>
         </div>
 
-        <div class="grid gap-4 xl:grid-cols-[1fr_320px]" id="main-grid">
-          <section class="flex min-h-[64vh] flex-col gap-4 pb-52">
+        <div class="flex gap-4" id="main-grid" style="min-height: 0">
+          <section class="flex min-h-[64vh] flex-col gap-4 pb-52 flex-1" style="min-width: 0">
             <div
               class="video-grid rounded-2xl border border-neutral-border bg-white p-3 shadow-sm"
               id="video-grid"
@@ -397,7 +397,9 @@
             </div>
           </section>
 
-          <aside aria-label="Room setup and connection info" class="space-y-4">
+          <div class="sidebar-splitter" id="sidebar-splitter" role="separator" aria-label="Resize sidebar" aria-orientation="vertical" tabindex="0"></div>
+
+          <aside id="sidebar-content" aria-label="Room setup and connection info" class="space-y-4" style="width: 320px; flex-shrink: 0">
             <div class="rounded-2xl border border-neutral-border bg-white p-4 shadow-sm">
               <h2
                 class="mb-3 flex items-center gap-2 text-sm font-bold uppercase tracking-wide text-gray-700"


### PR DESCRIPTION
 Introduced a draggable sidebar splitter for the Group Chat and Participants section, allowing users to dynamically adjust the layout. The implementation includes:
 * **Mouse & Touch Support**: Smooth dragging on both desktop and mobile devices.
 * **Keyboard Navigation**: Accessible resizing using Arrow Left/Right keys.
 * **Persistence**: Automatic saving and restoration of sidebar width via `localStorage`.
 * **Integrated UI**: Consolidated logic into the shared `ui.js` utility for better performance and maintainability.

<video src="https://github.com/user-attachments/assets/4200b79d-b206-4ba5-abf6-fe05d3f2b0db" controls width="600"></video>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added interactive sidebar resizing. Users can now drag the sidebar edge to adjust its width, or use keyboard arrow keys for precise control. Width preferences are automatically saved and restored on future visits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->