### PR TITLE
fix: resolve call glare deadlock in full-mesh group calls

### DIFF
--- a/public/js/video.js
+++ b/public/js/video.js
@@ -1457,9 +1457,19 @@ const VideoChat = (() => {
     });
 
     peer.on("call", async (incomingCall) => {
-      if (activeCalls.has(incomingCall.peer)) {
-        incomingCall.close();
-        return;
+      const existingCall = activeCalls.get(incomingCall.peer);
+      if (existingCall) {
+        // Call glare: both sides called each other simultaneously.
+        // Use lexicographic peer ID comparison as a deterministic tiebreaker:
+        // the peer with the lower ID keeps the caller role.
+        if (state.peerId < incomingCall.peer) {
+          // We have priority — keep our outgoing call, reject incoming.
+          incomingCall.close();
+          return;
+        }
+        // They have priority — drop our outgoing call, accept incoming.
+        existingCall.close();
+        activeCalls.delete(incomingCall.peer);
       }
       if (!consentGiven) {
         const ok = await askConsent(incomingCall.peer);
@@ -1811,7 +1821,11 @@ const VideoChat = (() => {
         data.ids.forEach((id) => {
           const peerId = typeof id === "string" ? id.trim() : "";
           if (peerId && peerId !== state.peerId && !activeCalls.has(peerId)) {
-            callPeer(peerId);
+            // Only initiate the call if we have the lower peer ID to avoid
+            // call glare (both sides calling simultaneously and deadlocking).
+            if (state.peerId < peerId) {
+              callPeer(peerId);
+            }
           }
         });
         return;

--- a/public/js/video.js
+++ b/public/js/video.js
@@ -1505,11 +1505,10 @@ const VideoChat = (() => {
             return;
           }
           // They have priority — drop our outgoing call, accept incoming.
-          // Mark the peer so its close handler skips destructive cleanup.
+          // Guard stays active until the replacement call is fully accepted.
           glareResolvingPeers.add(incomingCall.peer);
           existingCall.close();
           activeCalls.delete(incomingCall.peer);
-          glareResolvingPeers.delete(incomingCall.peer);
         } else {
           // An established call already exists with this peer; reject duplicate.
           incomingCall.close();
@@ -1519,6 +1518,7 @@ const VideoChat = (() => {
       if (!consentGiven) {
         const ok = await askConsent(incomingCall.peer);
         if (!ok) {
+          glareResolvingPeers.delete(incomingCall.peer);
           incomingCall.close();
           return;
         }
@@ -1526,11 +1526,13 @@ const VideoChat = (() => {
 
       const mediaOk = await startLocalMedia(walkieTalkieMode ? { audio: true, video: false } : undefined);
       if (!mediaOk) {
+        glareResolvingPeers.delete(incomingCall.peer);
         incomingCall.close();
         return;
       }
 
       activeCalls.set(incomingCall.peer, incomingCall);
+      glareResolvingPeers.delete(incomingCall.peer);
       updateParticipantsList();
 
       incomingCall.answer(voiceStream || localStream);

--- a/public/js/video.js
+++ b/public/js/video.js
@@ -46,6 +46,7 @@ const VideoChat = (() => {
   const lastProfileBroadcastAt = new Map(); // peerId -> timestamp
   let navigationInProgress = false;
   let isEndingCall = false;
+  const glareResolvingPeers = new Set();
   let walkieTalkieMode = false;
   let walkieFloorHolder = null;
   let pushToTalkPressed = false;
@@ -1468,8 +1469,11 @@ const VideoChat = (() => {
           return;
         }
         // They have priority — drop our outgoing call, accept incoming.
+        // Mark the peer so its close handler skips destructive cleanup.
+        glareResolvingPeers.add(incomingCall.peer);
         existingCall.close();
         activeCalls.delete(incomingCall.peer);
+        glareResolvingPeers.delete(incomingCall.peer);
       }
       if (!consentGiven) {
         const ok = await askConsent(incomingCall.peer);
@@ -1758,6 +1762,9 @@ const VideoChat = (() => {
     });
 
     call.on("close", () => {
+      // Skip destructive cleanup when closing a call as part of glare resolution,
+      // since we are about to accept a replacement call for the same peer.
+      if (glareResolvingPeers.has(remotePeerId)) return;
       activeCalls.delete(remotePeerId);
       const dataConn = activeDataConns.get(remotePeerId);
       if (dataConn) {
@@ -1821,11 +1828,7 @@ const VideoChat = (() => {
         data.ids.forEach((id) => {
           const peerId = typeof id === "string" ? id.trim() : "";
           if (peerId && peerId !== state.peerId && !activeCalls.has(peerId)) {
-            // Only initiate the call if we have the lower peer ID to avoid
-            // call glare (both sides calling simultaneously and deadlocking).
-            if (state.peerId < peerId) {
-              callPeer(peerId);
-            }
+            callPeer(peerId);
           }
         });
         return;

--- a/public/js/video.js
+++ b/public/js/video.js
@@ -1494,20 +1494,27 @@ const VideoChat = (() => {
     peer.on("call", async (incomingCall) => {
       const existingCall = activeCalls.get(incomingCall.peer);
       if (existingCall) {
-        // Call glare: both sides called each other simultaneously.
-        // Use lexicographic peer ID comparison as a deterministic tiebreaker:
-        // the peer with the lower ID keeps the caller role.
-        if (state.peerId < incomingCall.peer) {
-          // We have priority — keep our outgoing call, reject incoming.
+        const existingCallIsPending = existingCall.open !== true;
+        if (existingCallIsPending) {
+          // Call glare: both sides called each other simultaneously.
+          // Use lexicographic peer ID comparison as a deterministic tiebreaker:
+          // the peer with the lower ID keeps the caller role.
+          if (state.peerId < incomingCall.peer) {
+            // We have priority — keep our outgoing call, reject incoming.
+            incomingCall.close();
+            return;
+          }
+          // They have priority — drop our outgoing call, accept incoming.
+          // Mark the peer so its close handler skips destructive cleanup.
+          glareResolvingPeers.add(incomingCall.peer);
+          existingCall.close();
+          activeCalls.delete(incomingCall.peer);
+          glareResolvingPeers.delete(incomingCall.peer);
+        } else {
+          // An established call already exists with this peer; reject duplicate.
           incomingCall.close();
           return;
         }
-        // They have priority — drop our outgoing call, accept incoming.
-        // Mark the peer so its close handler skips destructive cleanup.
-        glareResolvingPeers.add(incomingCall.peer);
-        existingCall.close();
-        activeCalls.delete(incomingCall.peer);
-        glareResolvingPeers.delete(incomingCall.peer);
       }
       if (!consentGiven) {
         const ok = await askConsent(incomingCall.peer);


### PR DESCRIPTION
## Problem

In group calls with 3+ participants, peers frequently fail to connect with the error "Could not connect to peer". This was reported by OWASP members during a live SafeCloak session — users were not being placed in the same room and received connection errors.
### Root Cause: Call Glare Deadlock
When a new peer (C) joins a room, the host sends a peer list to C. C then calls all listed peers. Simultaneously, those listed peers also receive C's ID and call C. Both sides store the outgoing call in `activeCalls` *before* it's answered. When the incoming call arrives, `activeCalls.has(peer)` is already `true`, so both sides reject each other's call. Neither outgoing call is ever answered — they become zombie entries that never produce a stream.
### Example (3-person room)
1. **Host** creates room `J94NTFR`
2. **User1** joins via invite → connects to Host ✅ (2 peers works fine)
3. **User2** joins via invite → calls Host ✅
4. Host sends peer list `[User1]` to User2 → User2 calls User1
5. Host sends peer list `[User2]` to User1 → User1 calls User2
6. Both User1 and User2 already have each other in `activeCalls` → both reject → **deadlock** ❌
## Solution
Added a **deterministic tiebreaker** using lexicographic peer ID comparison to resolve call glare:
**1. `peer.on("call")` handler:** When an incoming call arrives from a peer we already have an outgoing call to, compare peer IDs. The peer with the lower ID keeps the caller role — the other side drops its outgoing call and accepts the incoming one.
**2. Peer list handler:** When receiving a peer list via data channel, only initiate calls to peers with a higher ID than ours (`state.peerId < peerId`). The peer with the lower ID will call us instead, preventing simultaneous calls entirely.
## Changes
- `public/js/video.js` — single file, ~15 lines added

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Deterministic resolution of simultaneous call attempts so only one side remains caller, preventing duplicate connections.
  * Incoming calls now defer or replace pending local calls using a predictable peer-ID tiebreaker; established calls still reject duplicates.
  * Call teardown is skipped while a handover is being resolved, preserving UI/chat state.
  * Glare handover state is cleared if consent is denied or local media setup fails, and after an incoming call is successfully answered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->