### PR TITLE
sync walkie-talkie floor state to late joiners

### DIFF
--- a/public/js/video.js
+++ b/public/js/video.js
@@ -639,18 +639,15 @@ const VideoChat = (() => {
       void setWalkieTalkieMode(true, "host");
     }
 
-    // Sync floor state for late joiners: if the sender reports who holds the floor,
-    // adopt it so the newcomer sees the correct speaker banner immediately.
-    if (
-      walkieTalkieMode &&
-      payload.walkie === true &&
-      typeof payload.floorHolder === "string" &&
-      payload.floorHolder !== "" &&
-      walkieFloorHolder === null
-    ) {
-      walkieFloorHolder = payload.floorHolder;
-      updateWalkieCueBanner();
-      syncControlButtons();
+    // Sync floor state from incoming profile so late joiners and stale states
+    // are corrected. Accept any update (including clear-to-free) when the value differs.
+    if (walkieTalkieMode && payload.walkie === true && typeof payload.floorHolder === "string") {
+      const incoming = payload.floorHolder === "" ? null : payload.floorHolder;
+      if (incoming !== walkieFloorHolder) {
+        walkieFloorHolder = incoming;
+        updateWalkieCueBanner();
+        syncControlButtons();
+      }
     }
   }
 

--- a/public/js/video.js
+++ b/public/js/video.js
@@ -311,6 +311,7 @@ const VideoChat = (() => {
       camOff: screenSharing ? false : isLocalCamOffState(),
       handRaised: localHandRaised,
       walkie: walkieTalkieMode,
+      floorHolder: walkieFloorHolder,
     };
   }
 
@@ -636,6 +637,20 @@ const VideoChat = (() => {
       !walkieTalkieMode
     ) {
       void setWalkieTalkieMode(true, "host");
+    }
+
+    // Sync floor state for late joiners: if the sender reports who holds the floor,
+    // adopt it so the newcomer sees the correct speaker banner immediately.
+    if (
+      walkieTalkieMode &&
+      payload.walkie === true &&
+      typeof payload.floorHolder === "string" &&
+      payload.floorHolder !== "" &&
+      walkieFloorHolder === null
+    ) {
+      walkieFloorHolder = payload.floorHolder;
+      updateWalkieCueBanner();
+      syncControlButtons();
     }
   }
 

--- a/public/js/video.js
+++ b/public/js/video.js
@@ -639,14 +639,21 @@ const VideoChat = (() => {
       void setWalkieTalkieMode(true, "host");
     }
 
-    // Sync floor state from incoming profile so late joiners and stale states
-    // are corrected. Accept any update (including clear-to-free) when the value differs.
-    if (walkieTalkieMode && payload.walkie === true && typeof payload.floorHolder === "string") {
-      const incoming = payload.floorHolder === "" ? null : payload.floorHolder;
-      if (incoming !== walkieFloorHolder) {
+    // Sync floor state from incoming profile for late joiners.
+    // Only adopt a non-null holder when local state is still free — this avoids
+    // a stale profile from one peer clobbering a correct state from another.
+    // Real-time releases are handled by the data-channel "floor" messages, not here.
+    if (
+      walkieTalkieMode &&
+      payload.walkie === true &&
+      (typeof payload.floorHolder === "string" || payload.floorHolder === null)
+    ) {
+      const incoming = payload.floorHolder ?? null;
+      if (incoming !== null && walkieFloorHolder === null) {
         walkieFloorHolder = incoming;
         updateWalkieCueBanner();
         syncControlButtons();
+        updateLocalTilePresentation();
       }
     }
   }


### PR DESCRIPTION
When a participant joins while someone already holds the push-to-talk floor, 
their screen showed "Floor is free" because walkieFloorHolder is local-only 
and was never shared.
Fix: include `floorHolder` in the profile payload so any peer that connects 
learns the current floor holder immediately from the first profile exchange.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where late joiners in walkie-talkie mode could show incorrect speaker indicators and disabled push-to-talk controls. New joiners now receive the current floor ownership on entry, ensuring the cue banner, push-to-talk controls, and local tile presentation reflect the live floor holder state immediately upon joining.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->